### PR TITLE
FIX: Allow Indeed search term with complex syntax

### DIFF
--- a/src/jobspy/scrapers/indeed/__init__.py
+++ b/src/jobspy/scrapers/indeed/__init__.py
@@ -90,10 +90,11 @@ class IndeedScraper(Scraper):
         jobs = []
         new_cursor = None
         filters = self._build_filters()
+        search_term = self.scraper_input.search_term.replace('"', '\\"') if self.scraper_input.search_term else ""
         query = self.job_search_query.format(
             what=(
-                f'what: "{self.scraper_input.search_term}"'
-                if self.scraper_input.search_term
+                f'what: "{search_term}"'
+                if search_term
                 else ""
             ),
             location=(


### PR DESCRIPTION
When scraping using Indeed, simple syntax must be used. Otherwise, for example using `search_term='"Python" AND "Java"'` it logs the following message:
`JobSpy - INFO - Indeed responded with status code: 400 (submit GitHub issue if this appears to be a beg)`

The suggested fix, it escapes the quote in order to be able to be processed. I've compared the results between the scrape and the job platform result with the same syntax and, sorted by date, it returns the same results.

Besides, with this change now it also can be used any expression included in the [Indeed syntax search guide](https://www.indeed.com/career-advice/career-development/boolean-search-strings)