### PR TITLE
FEAT: Optional conversion to annual and know salary source

### DIFF
--- a/src/jobspy/scrapers/__init__.py
+++ b/src/jobspy/scrapers/__init__.py
@@ -18,6 +18,9 @@ class Site(Enum):
     ZIP_RECRUITER = "zip_recruiter"
     GLASSDOOR = "glassdoor"
 
+class SalarySource(Enum):
+    DIRECT_DATA = "direct_data"
+    DESCRIPTION = "description"
 
 class ScraperInput(BaseModel):
     site_type: list[Site]


### PR DESCRIPTION
I suggest the following PR in order to be able to:
1. Enable/disable conversion to annual salary when scraping. However, I leave by default the current behavior of converting.
2. Have a field telling us how the salary was extracted in order to be able to distinguish when a salary is coming from a regex parsing or directly from the scraped data.

These two features are really interesting for our project, because we want to keep having the original `interval` of the offers.

Thanks for keeping this project, which is great for the community!