### PR TITLE
Add Malta for linkedin country support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "python-jobspy"
-version = "1.1.66"
+version = "1.1.67"
 description = "Job scraper for LinkedIn, Indeed, Glassdoor & ZipRecruiter"
 authors = ["Zachary Hampton <zachary@bunsly.com>", "Cullen Watson <cullen@bunsly.com>"]
 homepage = "https://github.com/Bunsly/JobSpy"

--- a/src/jobspy/jobs/__init__.py
+++ b/src/jobspy/jobs/__init__.py
@@ -93,6 +93,7 @@ class Country(Enum):
     KUWAIT = ("kuwait", "kw")
     LUXEMBOURG = ("luxembourg", "lu")
     MALAYSIA = ("malaysia", "malaysia:my", "com")
+    MALTA = ("malta", "malta:mt", "mt")
     MEXICO = ("mexico", "mx", "com.mx")
     MOROCCO = ("morocco", "ma")
     NETHERLANDS = ("netherlands", "nl", "nl")


### PR DESCRIPTION
Add Malta for LinkedIn and fix an error

```
Traceback:
Traceback (most recent call last):
  File "/home/user/.asdf/installs/python/3.12.6/lib/python3.12/site-packages/jobspy/scrapers/linkedin/__init__.py", line 147, in scrape
    job_post = self._process_job(job_card, job_id, fetch_desc)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/.asdf/installs/python/3.12.6/lib/python3.12/site-packages/jobspy/scrapers/linkedin/__init__.py", line 194, in _process_job
    location = self._get_location(metadata_card)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/.asdf/installs/python/3.12.6/lib/python3.12/site-packages/jobspy/scrapers/linkedin/__init__.py", line 303, in _get_locatio
n
    country = Country.from_string(country)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/.asdf/installs/python/3.12.6/lib/python3.12/site-packages/jobspy/jobs/__init__.py", line 165, in from_string
    raise ValueError(
ValueError: Invalid country string: 'malta'. Valid countries are: <snip>
```