### PR TITLE
Fix Google job search

### DIFF
--- a/src/jobspy/scrapers/google/__init__.py
+++ b/src/jobspy/scrapers/google/__init__.py
@@ -232,7 +232,7 @@ class GoogleJobsScraper(Scraper):
     def _find_job_info_initial_page(html_text: str):
         pattern = (
             f'520084652":('
-            + r"\[(?:[^\[\]]|\[(?:[^\[\]]|\[(?:[^\[\]]|\[[^\[\]]*\])*\])*\])*\])"
+            + r"\[.*?\]\s*])\s*}\s*]\s*]\s*]\s*]\s*]"
         )
         results = []
         matches = re.finditer(pattern, html_text)


### PR DESCRIPTION
The previous regex did not capture all expected matches in the returned content