### PR TITLE
fix(naukri): prevent str.find error by normalizing input and parsing (#289)

### DIFF
--- a/jobspy/naukri/__init__.py
+++ b/jobspy/naukri/__init__.py
@@ -164,12 +164,15 @@ class Naukri(Scraper):
         date_posted = self._parse_date(job.get("footerPlaceholderLabel"), job.get("createdDate"))
 
         job_url = f"https://www.naukri.com{job.get('jdURL', f'/job/{job_id}')}"
-        description = job.get("jobDescription") if full_descr else None
+        raw_description = job.get("jobDescription") if full_descr else None
+
+        job_type = parse_job_type(raw_description) if raw_description else None
+        company_industry = parse_company_industry(raw_description) if raw_description else None
+
+        description = raw_description
         if description and self.scraper_input.description_format == DescriptionFormat.MARKDOWN:
             description = markdown_converter(description)
 
-        job_type = parse_job_type(description) if description else None
-        company_industry = parse_company_industry(description) if description else None
         is_remote = is_job_remote(title, description or "", location)
         company_logo = job.get("logoPathV3") or job.get("logoPath")
 

--- a/jobspy/naukri/util.py
+++ b/jobspy/naukri/util.py
@@ -5,10 +5,12 @@ from jobspy.model import JobType, Location
 from jobspy.util import get_enum_from_job_type
 
 
-def parse_job_type(soup: BeautifulSoup) -> list[JobType] | None:
+def parse_job_type(soup: BeautifulSoup |str) -> list[JobType] | None:
     """
     Gets the job type from the job page
     """
+    if isinstance(soup, str):
+        soup = BeautifulSoup(soup, "html.parser")
     job_type_tag = soup.find("span", class_="job-type")
     if job_type_tag:
         job_type_str = job_type_tag.get_text(strip=True).lower().replace("-", "")
@@ -16,10 +18,12 @@ def parse_job_type(soup: BeautifulSoup) -> list[JobType] | None:
     return None
 
 
-def parse_company_industry(soup: BeautifulSoup) -> str | None:
+def parse_company_industry(soup: BeautifulSoup | str) -> str | None:
     """
     Gets the company industry from the job page
     """
+    if isinstance(soup, str):
+        soup = BeautifulSoup(soup, "html.parser")
     industry_tag = soup.find("span", class_="industry")
     return industry_tag.get_text(strip=True) if industry_tag else None
 


### PR DESCRIPTION
**Summary**
Fixes a runtime error “str.find() takes no keyword arguments” in the Naukri scraper when LINKEDIN_FETCH_DESCRIPTION=True and description_format='markdown'.

**Root cause**
A plain string (sometimes Markdown) was passed to BeautifulSoup parsing logic, so calling soup.find(...) with keyword args failed.

**Changes**
jobspy/naukri/util.py:
parse_company_industry now accepts BeautifulSoup | str and normalizes str to BeautifulSoup before find().

jobspy/naukri/init.py:
Parse job_type and company_industry from the raw HTML (jobDescription) before converting description to Markdown.

**Testing**
Ran a Naukri scrape with linkedin_fetch_description=True and description_format='markdown'; scraping completes without error.

Example run:
site='naukri', search_term='software engineer', location='Bengaluru', results_wanted=5
job_type/company_industry may remain None because Naukri’s jobDescription doesn’t include the specific selectors; this is expected and independent of the bug fix.

Issue
Fixes #289