### PR TITLE
feat: Implement thread-safe rate limiting for network session classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,10 +122,10 @@ Optional
 |    path to CA Certificate file for proxies
 |
 ├── rate_delay_min (int | float)
-|    minimum rate delay between network requests (must be specified together with rate_delay_max)
+|    (optional) minimum rate delay between network requests (must be specified together with rate_delay_max)
 |
 ├── rate_delay_max (int | float)
-|    maximum rate delay between network requests (must be specified together with rate_delay_max)
+|    (optional) maximum rate delay between network requests (must be specified together with rate_delay_min)
 ```
 
 ```

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ jobs = scrape_jobs(
     results_wanted=20,
     hours_old=72,
     country_indeed='USA',
+    rate_delay_min=1,    # in seconds
+    rate_delay_max=2,    # in seconds
     
     # linkedin_fetch_description=True # gets more info such as description, direct job url (slower)
     # proxies=["208.195.175.46:65095", "208.195.175.45:65095", "localhost"],
@@ -118,6 +120,12 @@ Optional
 |
 ├── ca_cert (str)
 |    path to CA Certificate file for proxies
+|
+├── rate_delay_min (int | float)
+|    minimum rate delay between network requests (must be specified together with rate_delay_max)
+|
+├── rate_delay_max (int | float)
+|    maximum rate delay between network requests (must be specified together with rate_delay_max)
 ```
 
 ```

--- a/jobspy/__init__.py
+++ b/jobspy/__init__.py
@@ -49,6 +49,8 @@ def scrape_jobs(
     enforce_annual_salary: bool = False,
     verbose: int = 0,
     user_agent: str = None,
+    rate_delay_min: float | None = None,
+    rate_delay_max: float | None = None,
     **kwargs,
 ) -> pd.DataFrame:
     """
@@ -103,7 +105,7 @@ def scrape_jobs(
 
     def scrape_site(site: Site) -> Tuple[str, JobResponse]:
         scraper_class = SCRAPER_MAPPING[site]
-        scraper = scraper_class(proxies=proxies, ca_cert=ca_cert, user_agent=user_agent)
+        scraper = scraper_class(proxies=proxies, ca_cert=ca_cert, user_agent=user_agen, rate_delay_min=rate_delay_min, rate_delay_max=rate_delay_max)
         scraped_data: JobResponse = scraper.scrape(scraper_input)
         cap_name = site.value.capitalize()
         site_name = "ZipRecruiter" if cap_name == "Zip_recruiter" else cap_name

--- a/jobspy/__init__.py
+++ b/jobspy/__init__.py
@@ -105,7 +105,7 @@ def scrape_jobs(
 
     def scrape_site(site: Site) -> Tuple[str, JobResponse]:
         scraper_class = SCRAPER_MAPPING[site]
-        scraper = scraper_class(proxies=proxies, ca_cert=ca_cert, user_agent=user_agen, rate_delay_min=rate_delay_min, rate_delay_max=rate_delay_max)
+        scraper = scraper_class(proxies=proxies, ca_cert=ca_cert, user_agent=user_agent, rate_delay_min=rate_delay_min, rate_delay_max=rate_delay_max)
         scraped_data: JobResponse = scraper.scrape(scraper_input)
         cap_name = site.value.capitalize()
         site_name = "ZipRecruiter" if cap_name == "Zip_recruiter" else cap_name

--- a/jobspy/__init__.py
+++ b/jobspy/__init__.py
@@ -49,8 +49,8 @@ def scrape_jobs(
     enforce_annual_salary: bool = False,
     verbose: int = 0,
     user_agent: str = None,
-    rate_delay_min: float | None = None,
-    rate_delay_max: float | None = None,
+    rate_delay_min: int | float | None = None,
+    rate_delay_max: int | float | None = None,
     **kwargs,
 ) -> pd.DataFrame:
     """

--- a/jobspy/bayt/__init__.py
+++ b/jobspy/bayt/__init__.py
@@ -25,7 +25,7 @@ class BaytScraper(Scraper):
     band_delay = 3
 
     def __init__(
-        self, proxies: list[str] | str | None = None, ca_cert: str | None = None, user_agent: str | None = None, rate_delay_min: float | None = None, rate_delay_max: float | None = None
+        self, proxies: list[str] | str | None = None, ca_cert: str | None = None, user_agent: str | None = None, rate_delay_min: int | float | None = None, rate_delay_max: int | float | None = None
     ):
         super().__init__(Site.BAYT, proxies=proxies, ca_cert=ca_cert)
         self.scraper_input = None

--- a/jobspy/bayt/__init__.py
+++ b/jobspy/bayt/__init__.py
@@ -25,7 +25,7 @@ class BaytScraper(Scraper):
     band_delay = 3
 
     def __init__(
-        self, proxies: list[str] | str | None = None, ca_cert: str | None = None, user_agent: str | None = None
+        self, proxies: list[str] | str | None = None, ca_cert: str | None = None, user_agent: str | None = None, rate_delay_min: float | None = None, rate_delay_max: float | None = None
     ):
         super().__init__(Site.BAYT, proxies=proxies, ca_cert=ca_cert)
         self.scraper_input = None
@@ -35,7 +35,7 @@ class BaytScraper(Scraper):
     def scrape(self, scraper_input: ScraperInput) -> JobResponse:
         self.scraper_input = scraper_input
         self.session = create_session(
-            proxies=self.proxies, ca_cert=self.ca_cert, is_tls=False, has_retry=True
+            proxies=self.proxies, ca_cert=self.ca_cert, is_tls=False, has_retry=True, rate_delay_min=rate_delay_min, rate_delay_max=rate_delay_max
         )
         job_list: list[JobPost] = []
         page = 1

--- a/jobspy/bayt/__init__.py
+++ b/jobspy/bayt/__init__.py
@@ -31,11 +31,13 @@ class BaytScraper(Scraper):
         self.scraper_input = None
         self.session = None
         self.country = "worldwide"
+        self.rate_delay_min = rate_delay_min
+        self.rate_delay_max = rate_delay_max
 
     def scrape(self, scraper_input: ScraperInput) -> JobResponse:
         self.scraper_input = scraper_input
         self.session = create_session(
-            proxies=self.proxies, ca_cert=self.ca_cert, is_tls=False, has_retry=True, rate_delay_min=rate_delay_min, rate_delay_max=rate_delay_max
+            proxies=self.proxies, ca_cert=self.ca_cert, is_tls=False, has_retry=True, rate_delay_min=self.rate_delay_min, rate_delay_max=self.rate_delay_max
         )
         job_list: list[JobPost] = []
         page = 1

--- a/jobspy/bdjobs/__init__.py
+++ b/jobspy/bdjobs/__init__.py
@@ -46,7 +46,7 @@ class BDJobs(Scraper):
     band_delay = 3
 
     def __init__(
-        self, proxies: list[str] | str | None = None, ca_cert: str | None = None, rate_delay_min: float | None = None, rate_delay_max: float | None = None
+        self, proxies: list[str] | str | None = None, ca_cert: str | None = None, rate_delay_min: int | float | None = None, rate_delay_max: int | float | None = None
     ):
         """
         Initializes BDJobsScraper with the BDJobs job search url

--- a/jobspy/bdjobs/__init__.py
+++ b/jobspy/bdjobs/__init__.py
@@ -46,7 +46,7 @@ class BDJobs(Scraper):
     band_delay = 3
 
     def __init__(
-        self, proxies: list[str] | str | None = None, ca_cert: str | None = None, rate_delay_min: int | float | None = None, rate_delay_max: int | float | None = None
+        self, proxies: list[str] | str | None = None, ca_cert: str | None = None, user_agent: str | None = None, rate_delay_min: int | float | None = None, rate_delay_max: int | float | None = None
     ):
         """
         Initializes BDJobsScraper with the BDJobs job search url

--- a/jobspy/bdjobs/__init__.py
+++ b/jobspy/bdjobs/__init__.py
@@ -46,7 +46,7 @@ class BDJobs(Scraper):
     band_delay = 3
 
     def __init__(
-        self, proxies: list[str] | str | None = None, ca_cert: str | None = None
+        self, proxies: list[str] | str | None = None, ca_cert: str | None = None, rate_delay_min: float | None = None, rate_delay_max: float | None = None
     ):
         """
         Initializes BDJobsScraper with the BDJobs job search url
@@ -57,8 +57,10 @@ class BDJobs(Scraper):
             ca_cert=ca_cert,
             is_tls=False,
             has_retry=True,
-            delay=5,
+            backoff_factor=5,
             clear_cookies=True,
+            rate_delay_min=rate_delay_min,
+            rate_delay_max=rate_delay_max,
         )
         self.session.headers.update(headers)
         self.scraper_input = None

--- a/jobspy/glassdoor/__init__.py
+++ b/jobspy/glassdoor/__init__.py
@@ -34,13 +34,13 @@ log = create_logger("Glassdoor")
 
 class Glassdoor(Scraper):
     def __init__(
-        self, proxies: list[str] | str | None = None, ca_cert: str | None = None, user_agent: str | None = None
+        self, proxies: list[str] | str | None = None, ca_cert: str | None = None, user_agent: str | None = None, rate_delay_min: float | None = None, rate_delay_max: float | None = None
     ):
         """
         Initializes GlassdoorScraper with the Glassdoor job search url
         """
         site = Site(Site.GLASSDOOR)
-        super().__init__(site, proxies=proxies, ca_cert=ca_cert, user_agent=user_agent)
+        super().__init__(site, proxies=proxies, ca_cert=ca_cert, user_agent=user_agent, rate_delay_min=rate_delay_min, rate_delay_max=rate_delay_max)
 
         self.base_url = None
         self.country = None

--- a/jobspy/glassdoor/__init__.py
+++ b/jobspy/glassdoor/__init__.py
@@ -40,7 +40,7 @@ class Glassdoor(Scraper):
         Initializes GlassdoorScraper with the Glassdoor job search url
         """
         site = Site(Site.GLASSDOOR)
-        super().__init__(site, proxies=proxies, ca_cert=ca_cert, user_agent=user_agent, rate_delay_min=rate_delay_min, rate_delay_max=rate_delay_max)
+        super().__init__(site, proxies=proxies, ca_cert=ca_cert, user_agent=user_agent)
 
         self.base_url = None
         self.country = None
@@ -48,6 +48,8 @@ class Glassdoor(Scraper):
         self.scraper_input = None
         self.jobs_per_page = 30
         self.max_pages = 30
+        self.rate_delay_min = rate_delay_min
+        self.rate_delay_max = rate_delay_max
         self.seen_urls = set()
 
     def scrape(self, scraper_input: ScraperInput) -> JobResponse:
@@ -61,7 +63,7 @@ class Glassdoor(Scraper):
         self.base_url = self.scraper_input.country.get_glassdoor_url()
 
         self.session = create_session(
-            proxies=self.proxies, ca_cert=self.ca_cert, has_retry=True
+            proxies=self.proxies, ca_cert=self.ca_cert, has_retry=True, rate_delay_min=self.rate_delay_min, rate_delay_max=self.rate_delay_max
         )
         token = self._get_csrf_token()
         headers["gd-csrf-token"] = token if token else fallback_token

--- a/jobspy/glassdoor/__init__.py
+++ b/jobspy/glassdoor/__init__.py
@@ -34,7 +34,7 @@ log = create_logger("Glassdoor")
 
 class Glassdoor(Scraper):
     def __init__(
-        self, proxies: list[str] | str | None = None, ca_cert: str | None = None, user_agent: str | None = None, rate_delay_min: float | None = None, rate_delay_max: float | None = None
+        self, proxies: list[str] | str | None = None, ca_cert: str | None = None, user_agent: str | None = None, rate_delay_min: int | float | None = None, rate_delay_max: int | float | None = None
     ):
         """
         Initializes GlassdoorScraper with the Glassdoor job search url

--- a/jobspy/google/__init__.py
+++ b/jobspy/google/__init__.py
@@ -28,7 +28,7 @@ class Google(Scraper):
         Initializes Google Scraper with the Goodle jobs search url
         """
         site = Site(Site.GOOGLE)
-        super().__init__(site, proxies=proxies, ca_cert=ca_cert, rate_delay_min=rate_delay_min, rate_delay_max=rate_delay_max)
+        super().__init__(site, proxies=proxies, ca_cert=ca_cert)
 
         self.country = None
         self.session = None
@@ -37,6 +37,8 @@ class Google(Scraper):
         self.seen_urls = set()
         self.url = "https://www.google.com/search"
         self.jobs_url = "https://www.google.com/async/callback:550"
+        self.rate_delay_min = rate_delay_min
+        self.rate_delay_max = rate_delay_max
 
     def scrape(self, scraper_input: ScraperInput) -> JobResponse:
         """
@@ -48,7 +50,7 @@ class Google(Scraper):
         self.scraper_input.results_wanted = min(900, scraper_input.results_wanted)
 
         self.session = create_session(
-            proxies=self.proxies, ca_cert=self.ca_cert, is_tls=False, has_retry=True
+            proxies=self.proxies, ca_cert=self.ca_cert, is_tls=False, has_retry=True, rate_delay_min=self.rate_delay_min, rate_delay_max=self.rate_delay_max
         )
         forward_cursor, job_list = self._get_initial_cursor_and_jobs()
         if forward_cursor is None:

--- a/jobspy/google/__init__.py
+++ b/jobspy/google/__init__.py
@@ -22,7 +22,7 @@ from jobspy.google.util import log, find_job_info_initial_page, find_job_info
 
 class Google(Scraper):
     def __init__(
-        self, proxies: list[str] | str | None = None, ca_cert: str | None = None, user_agent: str | None = None, rate_delay_min: float | None = None, rate_delay_max: float | None = None
+        self, proxies: list[str] | str | None = None, ca_cert: str | None = None, user_agent: str | None = None, rate_delay_min: int | float | None = None, rate_delay_max: int | float | None = None
     ):
         """
         Initializes Google Scraper with the Goodle jobs search url

--- a/jobspy/google/__init__.py
+++ b/jobspy/google/__init__.py
@@ -22,13 +22,13 @@ from jobspy.google.util import log, find_job_info_initial_page, find_job_info
 
 class Google(Scraper):
     def __init__(
-        self, proxies: list[str] | str | None = None, ca_cert: str | None = None, user_agent: str | None = None
+        self, proxies: list[str] | str | None = None, ca_cert: str | None = None, user_agent: str | None = None, rate_delay_min: float | None = None, rate_delay_max: float | None = None
     ):
         """
         Initializes Google Scraper with the Goodle jobs search url
         """
         site = Site(Site.GOOGLE)
-        super().__init__(site, proxies=proxies, ca_cert=ca_cert)
+        super().__init__(site, proxies=proxies, ca_cert=ca_cert, rate_delay_min=rate_delay_min, rate_delay_max=rate_delay_max)
 
         self.country = None
         self.session = None

--- a/jobspy/indeed/__init__.py
+++ b/jobspy/indeed/__init__.py
@@ -28,7 +28,7 @@ log = create_logger("Indeed")
 
 class Indeed(Scraper):
     def __init__(
-        self, proxies: list[str] | str | None = None, ca_cert: str | None = None, user_agent: str | None = None, rate_delay_min: float | None = None, rate_delay_max: float | None = None
+        self, proxies: list[str] | str | None = None, ca_cert: str | None = None, user_agent: str | None = None, rate_delay_min: int | float | None = None, rate_delay_max: int | float | None = None
     ):
         """
         Initializes IndeedScraper with the Indeed API url

--- a/jobspy/indeed/__init__.py
+++ b/jobspy/indeed/__init__.py
@@ -28,7 +28,7 @@ log = create_logger("Indeed")
 
 class Indeed(Scraper):
     def __init__(
-        self, proxies: list[str] | str | None = None, ca_cert: str | None = None, user_agent: str | None = None
+        self, proxies: list[str] | str | None = None, ca_cert: str | None = None, user_agent: str | None = None, rate_delay_min: float | None = None, rate_delay_max: float | None = None
     ):
         """
         Initializes IndeedScraper with the Indeed API url
@@ -36,7 +36,7 @@ class Indeed(Scraper):
         super().__init__(Site.INDEED, proxies=proxies)
 
         self.session = create_session(
-            proxies=self.proxies, ca_cert=ca_cert, is_tls=False
+            proxies=self.proxies, ca_cert=ca_cert, is_tls=False, rate_delay_min=rate_delay_min, rate_delay_max=rate_delay_max
         )
         self.scraper_input = None
         self.jobs_per_page = 100

--- a/jobspy/linkedin/__init__.py
+++ b/jobspy/linkedin/__init__.py
@@ -51,7 +51,7 @@ class LinkedIn(Scraper):
     jobs_per_page = 25
 
     def __init__(
-        self, proxies: list[str] | str | None = None, ca_cert: str | None = None, user_agent: str | None = None, rate_delay_min: float | None = None, rate_delay_max: float | None = None
+        self, proxies: list[str] | str | None = None, ca_cert: str | None = None, user_agent: str | None = None, rate_delay_min: int | float | None = None, rate_delay_max: int | float | None = None
     ):
         """
         Initializes LinkedInScraper with the LinkedIn job search url

--- a/jobspy/linkedin/__init__.py
+++ b/jobspy/linkedin/__init__.py
@@ -51,7 +51,7 @@ class LinkedIn(Scraper):
     jobs_per_page = 25
 
     def __init__(
-        self, proxies: list[str] | str | None = None, ca_cert: str | None = None, user_agent: str | None = None
+        self, proxies: list[str] | str | None = None, ca_cert: str | None = None, user_agent: str | None = None, rate_delay_min: float | None = None, rate_delay_max: float | None = None
     ):
         """
         Initializes LinkedInScraper with the LinkedIn job search url
@@ -62,8 +62,10 @@ class LinkedIn(Scraper):
             ca_cert=ca_cert,
             is_tls=False,
             has_retry=True,
-            delay=5,
+            backoff_factor=5,
             clear_cookies=True,
+            rate_delay_min=rate_delay_min,
+            rate_delay_max=rate_delay_max,
         )
         self.session.headers.update(headers)
         self.scraper_input = None

--- a/jobspy/naukri/__init__.py
+++ b/jobspy/naukri/__init__.py
@@ -44,7 +44,7 @@ class Naukri(Scraper):
     jobs_per_page = 20  
 
     def __init__(
-        self, proxies: list[str] | str | None = None, ca_cert: str | None = None, user_agent: str | None = None
+        self, proxies: list[str] | str | None = None, ca_cert: str | None = None, user_agent: str | None = None, rate_delay_min: float | None = None, rate_delay_max: float | None = None
     ):
         """
         Initializes NaukriScraper with the Naukri API URL
@@ -55,8 +55,10 @@ class Naukri(Scraper):
             ca_cert=ca_cert,
             is_tls=False,
             has_retry=True,
-            delay=5,
+            backoff_factor=5,
             clear_cookies=True,
+            rate_delay_min=rate_delay_min,
+            rate_delay_max=rate_delay_max,
         )
         self.session.headers.update(naukri_headers)
         self.scraper_input = None

--- a/jobspy/naukri/__init__.py
+++ b/jobspy/naukri/__init__.py
@@ -44,7 +44,7 @@ class Naukri(Scraper):
     jobs_per_page = 20  
 
     def __init__(
-        self, proxies: list[str] | str | None = None, ca_cert: str | None = None, user_agent: str | None = None, rate_delay_min: float | None = None, rate_delay_max: float | None = None
+        self, proxies: list[str] | str | None = None, ca_cert: str | None = None, user_agent: str | None = None, rate_delay_min: int | float | None = None, rate_delay_max: int | float | None = None
     ):
         """
         Initializes NaukriScraper with the Naukri API URL

--- a/jobspy/util.py
+++ b/jobspy/util.py
@@ -86,12 +86,9 @@ class RateLimiter:
         with self.rate_delay_lock:
             time_elapsed = time.monotonic() - self.last_request_time
             sleep_time = delay_seconds - time_elapsed
-
-            print(f"TEST: {self.last_request_time} / {time_elapsed} / {sleep_time}")
             if sleep_time > 0:
                 time.sleep(sleep_time)
 
-            # Update the last request time *after* any potential sleep
             self.last_request_time = time.monotonic()
 
 

--- a/jobspy/util.py
+++ b/jobspy/util.py
@@ -59,13 +59,13 @@ class RateLimiter:
     A thread-safe rate limiter to enforce a delay between operations.
 
     Args:
-        rate_delay_min (float | None):
+        rate_delay_min (int | float | None):
             The minimum time in seconds to wait since the last request.
-        rate_delay_max (float | None):
+        rate_delay_max (int | float | None):
             The maximum time in seconds to wait since the last request.
             If None, the delay will be fixed at rate_delay_min.
     """
-    def __init__(self, rate_delay_min: float | None, rate_delay_max: float | None):
+    def __init__(self, rate_delay_min: int | float | None, rate_delay_max: int | float | None):
         self.rate_delay_min = rate_delay_min
         self.rate_delay_max = rate_delay_max
         self.rate_delay_lock = threading.Lock()
@@ -79,7 +79,7 @@ class RateLimiter:
         the time elapsed since the last request and waits if necessary.
         """
 
-        if not isinstance(self.rate_delay_min, float) or not isinstance(self.rate_delay_max, float):
+        if not isinstance(self.rate_delay_min, (int, float)) or not isinstance(self.rate_delay_max, (int, float)):
             return
 
         delay_seconds = random.uniform(self.rate_delay_min, self.rate_delay_max)
@@ -97,7 +97,7 @@ class RateLimiter:
 
 
 class RequestsRotating(RotatingProxySession, requests.Session):
-    def __init__(self, proxies=None, has_retry=False, backoff_factor=1, clear_cookies=False, rate_delay_min: float | None = None, rate_delay_max: float | None = None):
+    def __init__(self, proxies=None, has_retry=False, backoff_factor=1, clear_cookies=False, rate_delay_min: int | float | None = None, rate_delay_max: int | float | None = None):
         RotatingProxySession.__init__(self, proxies=proxies)
         requests.Session.__init__(self)
         self.clear_cookies = clear_cookies
@@ -134,7 +134,7 @@ class RequestsRotating(RotatingProxySession, requests.Session):
 
 
 class TLSRotating(RotatingProxySession, tls_client.Session):
-    def __init__(self, proxies=None, rate_delay_min: float | None = None, rate_delay_max: float | None = None):
+    def __init__(self, proxies=None, rate_delay_min: int | float | None = None, rate_delay_max: int | float | None = None):
         RotatingProxySession.__init__(self, proxies=proxies)
         tls_client.Session.__init__(self, random_tls_extension_order=True)
         self.rate_limiter = RateLimiter(rate_delay_min, rate_delay_max)
@@ -161,8 +161,8 @@ def create_session(
     has_retry: bool = False,
     backoff_factor: int = 1,
     clear_cookies: bool = False,
-    rate_delay_min: float | None = None,
-    rate_delay_max: float | None = None,
+    rate_delay_min: int | float | None = None,
+    rate_delay_max: int | float | None = None,
 ) -> requests.Session:
     """
     Creates a requests session with optional tls, proxy, and retry settings.

--- a/jobspy/util.py
+++ b/jobspy/util.py
@@ -4,7 +4,6 @@ import logging
 import re
 from itertools import cycle
 import random
-import request
 import threading
 import time
 

--- a/jobspy/util.py
+++ b/jobspy/util.py
@@ -63,7 +63,6 @@ class RateLimiter:
             The minimum time in seconds to wait since the last request.
         rate_delay_max (int | float | None):
             The maximum time in seconds to wait since the last request.
-            If None, the delay will be fixed at rate_delay_min.
     """
     def __init__(self, rate_delay_min: int | float | None, rate_delay_max: int | float | None):
         self.rate_delay_min = rate_delay_min

--- a/jobspy/ziprecruiter/__init__.py
+++ b/jobspy/ziprecruiter/__init__.py
@@ -38,7 +38,7 @@ class ZipRecruiter(Scraper):
     api_url = "https://api.ziprecruiter.com"
 
     def __init__(
-        self, proxies: list[str] | str | None = None, ca_cert: str | None = None, user_agent: str | None = None, rate_delay_min: float | None = None, rate_delay_max: float | None = None
+        self, proxies: list[str] | str | None = None, ca_cert: str | None = None, user_agent: str | None = None, rate_delay_min: int | float | None = None, rate_delay_max: int | float | None = None
     ):
         """
         Initializes ZipRecruiterScraper with the ZipRecruiter job search url

--- a/jobspy/ziprecruiter/__init__.py
+++ b/jobspy/ziprecruiter/__init__.py
@@ -38,7 +38,7 @@ class ZipRecruiter(Scraper):
     api_url = "https://api.ziprecruiter.com"
 
     def __init__(
-        self, proxies: list[str] | str | None = None, ca_cert: str | None = None, user_agent: str | None = None
+        self, proxies: list[str] | str | None = None, ca_cert: str | None = None, user_agent: str | None = None, rate_delay_min: float | None = None, rate_delay_max: float | None = None
     ):
         """
         Initializes ZipRecruiterScraper with the ZipRecruiter job search url
@@ -46,7 +46,7 @@ class ZipRecruiter(Scraper):
         super().__init__(Site.ZIP_RECRUITER, proxies=proxies)
 
         self.scraper_input = None
-        self.session = create_session(proxies=proxies, ca_cert=ca_cert)
+        self.session = create_session(proxies=proxies, ca_cert=ca_cert, rate_delay_min=rate_delay_min, rate_delay_max=rate_delay_max)
         self.session.headers.update(headers)
         self._get_cookies()
 


### PR DESCRIPTION
**Summary**
This pull request introduces a new, thread-safe rate-limiting capability to the RequestsRotating and TLSRotating session classes. Users can now specify a minimum and maximum delay between requests to avoid overwhelming servers or triggering anti-bot mechanisms. A delay interval, randomly chosen between the minimum and maximum, will then be chosen.

**Motivation**
When performing automated requests at a high frequency, it's common to encounter rate limits imposed by the target server (e.g., HTTP 429 "Too Many Requests"). This can result in temporary or permanent IP blocks.

Implementing a client-side rate limiter provides a robust mechanism to control request frequency, increasing the reliability and success rate of long-running tasks and promoting more responsible scraping/automation practices.

**Implementation Details**
New RateLimiter Class:
A dedicated, reusable RateLimiter class has been created to encapsulate all rate-limiting logic.
It uses a threading.Lock to ensure atomicity, making it safe for use across multiple threads sharing the same session object.
It utilizes time.monotonic() for accurate time interval measurement, which is not affected by system time changes.
It supports both fixed delays (by providing rate_delay_min only) and randomized delays within a range (by providing both rate_delay_min and rate_delay_max).

Integration with Session Classes:
The __init__ methods of RequestsRotating and TLSRotating have been updated to accept rate_delay_min and rate_delay_max arguments.
An instance of RateLimiter is created within each session.
A call to self.rate_limiter.enforce_delay() has been added at the very beginning of the request() and execute_request() methods to ensure the delay is enforced before any network activity occurs.

**How to Use**
Users can now instantiate the session classes with the new rate-limiting parameters:
code
```
    all_job_posts = scrape_jobs(
        site_name=["indeed"], # , "linkedin", "zip_recruiter", "google"], # "glassdoor", "bayt", "naukri", "bdjobs"
        search_term="software",
        google_search_term="software engineer jobs near San Francisco, CA since yesterday",
        location="San Francisco, CA",
        results_wanted=num_job_posts,
        hours_old=30*24,
        country_indeed='USA',
        rate_delay_min=1,  # in seconds
        rate_delay_max=2,  # in seconds
    )
```