### PR TITLE
Add ChatGPT deep research integration for JobSpy

### DIFF
--- a/CHATGPT_GUIDE.md
+++ b/CHATGPT_GUIDE.md
@@ -1,0 +1,388 @@
+# ChatGPT Deep Research Integration Guide
+
+This guide enables ChatGPT and other LLMs to effectively use JobSpy for job market research, BD intelligence, and automated job searches.
+
+## Quick Start for ChatGPT
+
+### Installation Check
+```python
+# First, verify JobSpy is installed
+try:
+    from jobspy import scrape_jobs
+    print("JobSpy is ready!")
+except ImportError:
+    import subprocess
+    subprocess.run(["pip", "install", "python-jobspy"])
+    from jobspy import scrape_jobs
+```
+
+### Basic Search Pattern
+```python
+from jobspy import scrape_jobs
+import json
+
+# Search for jobs
+jobs = scrape_jobs(
+    site_name=["indeed", "linkedin"],
+    search_term="YOUR_SEARCH_TERM",
+    location="LOCATION",
+    results_wanted=15,
+    verbose=0
+)
+
+# Convert to JSON for analysis
+result = {
+    "count": len(jobs),
+    "jobs": jobs.to_dict(orient="records")
+}
+print(json.dumps(result, indent=2, default=str))
+```
+
+---
+
+## Prompt Templates for ChatGPT
+
+### 1. General Job Search
+**User Prompt:**
+> "Find [NUMBER] [JOB_TITLE] jobs in [LOCATION]"
+
+**ChatGPT Action:**
+```python
+from jobspy import scrape_jobs
+import json
+
+jobs = scrape_jobs(
+    site_name=["indeed", "linkedin"],
+    search_term="[JOB_TITLE]",
+    location="[LOCATION]",
+    results_wanted=[NUMBER],
+    verbose=0
+)
+
+# Display results
+for _, job in jobs.head(10).iterrows():
+    print(f"• {job['title']} at {job['company']}")
+    print(f"  Location: {job['location']}")
+    print(f"  URL: {job['job_url']}\n")
+```
+
+### 2. Remote Job Search
+**User Prompt:**
+> "Find remote [JOB_TITLE] jobs posted in the last [HOURS] hours"
+
+**ChatGPT Action:**
+```python
+jobs = scrape_jobs(
+    site_name=["indeed", "linkedin"],
+    search_term="[JOB_TITLE]",
+    is_remote=True,
+    hours_old=[HOURS],
+    results_wanted=20,
+    verbose=0
+)
+```
+
+### 3. Salary Research
+**User Prompt:**
+> "What's the salary range for [JOB_TITLE] in [LOCATION]?"
+
+**ChatGPT Action:**
+```python
+jobs = scrape_jobs(
+    site_name=["indeed", "glassdoor"],
+    search_term="[JOB_TITLE]",
+    location="[LOCATION]",
+    results_wanted=50,
+    verbose=0
+)
+
+# Analyze salary data
+salaries = jobs[jobs['min_amount'].notna()][['title', 'company', 'min_amount', 'max_amount', 'interval']]
+print(f"Salary data from {len(salaries)} postings:")
+print(f"Range: ${salaries['min_amount'].min():,.0f} - ${salaries['max_amount'].max():,.0f}")
+print(f"Median: ${salaries[['min_amount', 'max_amount']].mean().mean():,.0f}")
+```
+
+### 4. Company-Specific Search
+**User Prompt:**
+> "Find all jobs at [COMPANY_NAME]"
+
+**ChatGPT Action:**
+```python
+jobs = scrape_jobs(
+    site_name=["indeed"],
+    search_term=f'"{[COMPANY_NAME]}"',  # Exact match
+    results_wanted=50,
+    verbose=0
+)
+
+company_jobs = jobs[jobs['company'].str.contains('[COMPANY_NAME]', case=False, na=False)]
+print(f"Found {len(company_jobs)} jobs at [COMPANY_NAME]")
+```
+
+### 5. BD Intelligence - Hiring Trends
+**User Prompt:**
+> "Which companies are hiring the most [JOB_TYPE] in [INDUSTRY/LOCATION]?"
+
+**ChatGPT Action:**
+```python
+jobs = scrape_jobs(
+    site_name=["indeed", "linkedin"],
+    search_term="[JOB_TYPE]",
+    location="[LOCATION]",
+    results_wanted=100,
+    verbose=0
+)
+
+# Analyze by company
+company_counts = jobs['company'].value_counts().head(15)
+print("Top Hiring Companies:")
+for company, count in company_counts.items():
+    print(f"  {company}: {count} openings")
+```
+
+### 6. Federal/Cleared Job Search
+**User Prompt:**
+> "Find [CLEARANCE_LEVEL] cleared [JOB_TITLE] positions"
+
+**ChatGPT Action:**
+```python
+jobs = scrape_jobs(
+    site_name=["indeed", "linkedin"],
+    search_term=f"[JOB_TITLE] [CLEARANCE_LEVEL]",
+    location="Washington, DC",
+    results_wanted=30,
+    verbose=0
+)
+```
+
+### 7. Competitor Analysis
+**User Prompt:**
+> "What positions are [COMPETITOR_COMPANY] hiring for?"
+
+**ChatGPT Action:**
+```python
+jobs = scrape_jobs(
+    site_name=["indeed"],
+    search_term=f'"{[COMPETITOR_COMPANY]}"',
+    results_wanted=50,
+    verbose=0
+)
+
+# Filter and analyze
+competitor_jobs = jobs[jobs['company'].str.contains('[COMPETITOR_COMPANY]', case=False, na=False)]
+role_distribution = competitor_jobs['title'].value_counts()
+print(f"Roles at [COMPETITOR_COMPANY]:\n{role_distribution}")
+```
+
+---
+
+## CLI Usage for ChatGPT Code Execution
+
+The CLI provides a simpler interface when using code execution:
+
+```bash
+# Basic search
+python jobspy_cli.py --search "data scientist" --location "NYC" --format json
+
+# Remote jobs with filters
+python jobspy_cli.py --search "software engineer" --remote --hours 48 --results 20
+
+# Multiple sites
+python jobspy_cli.py --search "project manager" --sites indeed,linkedin,glassdoor
+
+# JSON input mode (for complex queries)
+echo '{"search_term": "python developer", "location": "Remote", "results_wanted": 10}' | python jobspy_cli.py --json-input
+```
+
+---
+
+## Output Formats
+
+### JSON Format (Recommended for LLM)
+```json
+{
+  "success": true,
+  "count": 15,
+  "jobs": [
+    {
+      "site": "indeed",
+      "title": "Software Engineer",
+      "company": "TechCorp",
+      "location": "San Francisco, CA",
+      "job_type": "fulltime",
+      "min_amount": 120000,
+      "max_amount": 180000,
+      "interval": "yearly",
+      "job_url": "https://indeed.com/...",
+      "description": "Job description here...",
+      "date_posted": "2025-01-15",
+      "is_remote": false
+    }
+  ]
+}
+```
+
+### Key Fields for Analysis
+| Field | Description | Use Case |
+|-------|-------------|----------|
+| `title` | Job title | Role identification |
+| `company` | Company name | BD targeting |
+| `location` | Job location | Geographic analysis |
+| `min_amount`/`max_amount` | Salary range | Compensation research |
+| `interval` | Salary period | Normalize salaries |
+| `job_url` | Direct link | Reference/verification |
+| `description` | Full job description | Skills extraction |
+| `date_posted` | Posting date | Freshness filter |
+| `is_remote` | Remote flag | Work arrangement |
+
+---
+
+## Best Practices for ChatGPT
+
+### 1. Start with Indeed
+Indeed has the best coverage and no rate limiting. Start searches here:
+```python
+jobs = scrape_jobs(site_name=["indeed"], ...)
+```
+
+### 2. Use Appropriate Result Counts
+- Quick overview: `results_wanted=10`
+- Standard search: `results_wanted=20`
+- Comprehensive analysis: `results_wanted=50-100`
+
+### 3. Filter by Recency
+Use `hours_old` for fresh postings:
+```python
+jobs = scrape_jobs(..., hours_old=24)  # Last 24 hours
+jobs = scrape_jobs(..., hours_old=72)  # Last 3 days
+jobs = scrape_jobs(..., hours_old=168) # Last week
+```
+
+### 4. Handle Empty Results
+```python
+jobs = scrape_jobs(...)
+if jobs.empty:
+    print("No jobs found. Try broadening your search.")
+else:
+    # Process results
+```
+
+### 5. Use Boolean Search Operators
+Indeed supports advanced search:
+```python
+# Must include term
+search_term = '"software engineer"'
+
+# Exclude terms
+search_term = 'python developer -junior -entry'
+
+# OR combinations
+search_term = '(python OR java) developer senior'
+```
+
+---
+
+## Advanced Use Cases
+
+### BD Intelligence: Growth Signals
+```python
+def identify_growth_companies(industry_keyword, location):
+    """Find companies with high hiring activity (growth signals)"""
+    jobs = scrape_jobs(
+        site_name=["indeed", "linkedin"],
+        search_term=industry_keyword,
+        location=location,
+        results_wanted=100,
+        hours_old=168,  # Last week
+        verbose=0
+    )
+
+    company_analysis = jobs.groupby('company').agg({
+        'title': 'count',
+        'location': lambda x: list(set(x))
+    }).rename(columns={'title': 'openings'})
+
+    growth_companies = company_analysis[company_analysis['openings'] >= 5]
+    return growth_companies.sort_values('openings', ascending=False)
+```
+
+### CIS Labor Category Mapping
+```python
+def extract_role_requirements(job_title, location):
+    """Extract duties and qualifications for labor category mapping"""
+    jobs = scrape_jobs(
+        site_name=["indeed"],
+        search_term=job_title,
+        location=location,
+        results_wanted=20,
+        linkedin_fetch_description=True,
+        verbose=0
+    )
+
+    # Return descriptions for analysis
+    return jobs[['title', 'company', 'description']].to_dict(orient='records')
+```
+
+### Competitor Staffing Monitor
+```python
+COMPETITOR_STAFFING = [
+    "Insight Global", "TEKsystems", "Apex Systems",
+    "Belcan", "GDIT", "Booz Allen Hamilton"
+]
+
+def monitor_competitors():
+    """Monitor hiring activity at competitor staffing companies"""
+    results = {}
+    for company in COMPETITOR_STAFFING:
+        jobs = scrape_jobs(
+            site_name=["indeed"],
+            search_term=f'"{company}"',
+            results_wanted=30,
+            verbose=0
+        )
+        results[company] = {
+            "openings": len(jobs),
+            "roles": jobs['title'].tolist()[:10]
+        }
+    return results
+```
+
+---
+
+## Troubleshooting
+
+### Rate Limiting (429 Error)
+- **Solution**: Use proxies or switch to Indeed (no rate limiting)
+```python
+jobs = scrape_jobs(..., proxies=["proxy1:port", "proxy2:port"])
+```
+
+### No Results
+- Broaden search term
+- Remove location filter
+- Try different sites
+- Check spelling
+
+### LinkedIn Issues
+- LinkedIn is restrictive; use proxies
+- Set `linkedin_fetch_description=False` for faster results
+- Consider using Indeed as primary source
+
+---
+
+## Reference
+
+### Supported Sites
+| Site | Coverage | Notes |
+|------|----------|-------|
+| `indeed` | Global | Best choice, no rate limits |
+| `linkedin` | Global | Requires proxies for heavy use |
+| `glassdoor` | Major countries | Includes company reviews |
+| `zip_recruiter` | US/Canada | Good salary data |
+| `google` | Global | Aggregates multiple sources |
+| `bayt` | Middle East | Regional specialist |
+| `naukri` | India | Regional specialist |
+
+### Full Parameter List
+See `tool_manifest.json` for complete API documentation.

--- a/README.md
+++ b/README.md
@@ -258,3 +258,69 @@ Naukri specific
 ├── vacancy_count
 └── work_from_home_type
 ```
+
+---
+
+## ChatGPT & LLM Integration
+
+JobSpy is optimized for use with ChatGPT and other LLMs for automated job research and BD intelligence gathering.
+
+### Quick Start for ChatGPT
+
+```python
+from jobspy import scrape_jobs
+import json
+
+# Search and return JSON
+jobs = scrape_jobs(
+    site_name=["indeed", "linkedin"],
+    search_term="software engineer",
+    location="Remote",
+    results_wanted=10,
+    verbose=0
+)
+
+# Convert to JSON for LLM processing
+result = {"count": len(jobs), "jobs": jobs.to_dict(orient="records")}
+print(json.dumps(result, indent=2, default=str))
+```
+
+### CLI for Code Execution
+
+A CLI wrapper is provided for easier ChatGPT code execution:
+
+```bash
+# Basic search with JSON output
+python jobspy_cli.py --search "data analyst" --location "NYC" --format json
+
+# Remote jobs from last 48 hours
+python jobspy_cli.py --search "python developer" --remote --hours 48 --results 20
+
+# Multi-site search
+python jobspy_cli.py --search "project manager" --sites indeed,linkedin,glassdoor
+
+# JSON input mode
+echo '{"search_term": "DevOps", "location": "Remote"}' | python jobspy_cli.py --json-input
+```
+
+### Documentation
+
+- **[CHATGPT_GUIDE.md](CHATGPT_GUIDE.md)** - Complete ChatGPT integration guide with prompt templates
+- **[tool_manifest.json](tool_manifest.json)** - Machine-readable tool metadata for MCP servers
+- **[examples/](examples/)** - Ready-to-use example scripts:
+  - `basic_search.py` - Simple job search
+  - `json_output_example.py` - JSON output for LLMs
+  - `bd_intelligence_search.py` - BD market intelligence
+  - `federal_contractor_search.py` - Federal/cleared job searches
+
+### Use Cases for ChatGPT
+
+| Use Case | Example Prompt |
+|----------|----------------|
+| Job Search | "Find 10 Python developer jobs in NYC" |
+| Salary Research | "What's the salary range for data scientists in SF?" |
+| Company Intel | "What positions is Google hiring for?" |
+| BD Intelligence | "Which companies are hiring the most cloud engineers?" |
+| Market Trends | "Show remote job trends for DevOps roles" |
+
+For detailed ChatGPT prompt templates and examples, see [CHATGPT_GUIDE.md](CHATGPT_GUIDE.md).

--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,0 +1,12 @@
+"""
+JobSpy Examples
+
+This directory contains example scripts demonstrating various JobSpy use cases:
+
+- basic_search.py: Simple job search across multiple boards
+- json_output_example.py: JSON output formatting for LLM integration
+- bd_intelligence_search.py: Business development market intelligence
+- federal_contractor_search.py: Federal contractor and cleared job searches
+
+For ChatGPT integration, see CHATGPT_GUIDE.md in the root directory.
+"""

--- a/examples/basic_search.py
+++ b/examples/basic_search.py
@@ -1,0 +1,48 @@
+"""
+Basic Job Search Example
+
+This example demonstrates a simple job search across multiple job boards.
+Perfect for ChatGPT to use as a reference for basic queries.
+
+Usage:
+    python examples/basic_search.py
+"""
+
+from jobspy import scrape_jobs
+import json
+
+def basic_job_search():
+    """
+    Search for software engineer jobs in San Francisco.
+    Returns results as both DataFrame and JSON for flexibility.
+    """
+    jobs = scrape_jobs(
+        site_name=["indeed", "linkedin"],
+        search_term="software engineer",
+        location="San Francisco, CA",
+        results_wanted=10,
+        hours_old=72,  # Jobs posted in last 3 days
+        country_indeed="usa",
+        verbose=0  # Suppress logging
+    )
+
+    print(f"Found {len(jobs)} jobs\n")
+
+    # Display as table
+    print("=== Results Preview ===")
+    print(jobs[["site", "title", "company", "location"]].head(5).to_string(index=False))
+
+    # Convert to JSON for LLM consumption
+    jobs_json = jobs.to_dict(orient="records")
+
+    return {
+        "success": True,
+        "count": len(jobs),
+        "jobs": jobs_json
+    }
+
+
+if __name__ == "__main__":
+    result = basic_job_search()
+    print(f"\n=== JSON Output ===")
+    print(json.dumps(result, indent=2, default=str)[:2000] + "...")

--- a/examples/bd_intelligence_search.py
+++ b/examples/bd_intelligence_search.py
@@ -1,0 +1,261 @@
+"""
+Business Development Intelligence Search
+
+This example demonstrates using JobSpy for BD intelligence gathering:
+- Identifying companies with high hiring activity (growth signals)
+- Monitoring competitor hiring patterns
+- Finding opportunities based on job postings
+
+Perfect for ChatGPT-assisted BD research and lead scoring.
+
+Usage:
+    python examples/bd_intelligence_search.py
+"""
+
+from jobspy import scrape_jobs
+from collections import defaultdict
+from datetime import datetime
+import json
+
+
+def analyze_hiring_trends(
+    search_term: str,
+    location: str = "",
+    results_wanted: int = 100
+) -> dict:
+    """
+    Analyze hiring trends for a given search term.
+    Useful for identifying companies with growth signals.
+
+    Returns analysis including:
+    - Companies sorted by number of openings
+    - Job type distribution
+    - Salary ranges
+    - Remote vs on-site breakdown
+    """
+
+    jobs_df = scrape_jobs(
+        site_name=["indeed", "linkedin"],
+        search_term=search_term,
+        location=location,
+        results_wanted=results_wanted,
+        country_indeed="usa",
+        verbose=0
+    )
+
+    if jobs_df.empty:
+        return {"success": False, "error": "No jobs found", "count": 0}
+
+    # Company analysis
+    company_counts = defaultdict(lambda: {"count": 0, "titles": [], "locations": set()})
+    for _, job in jobs_df.iterrows():
+        company = job.get("company", "Unknown")
+        company_counts[company]["count"] += 1
+        company_counts[company]["titles"].append(job.get("title", "N/A"))
+        if job.get("location"):
+            company_counts[company]["locations"].add(job["location"])
+
+    # Sort by hiring volume
+    top_companies = sorted(
+        [
+            {
+                "company": k,
+                "openings": v["count"],
+                "sample_roles": list(set(v["titles"]))[:5],
+                "locations": list(v["locations"])
+            }
+            for k, v in company_counts.items()
+        ],
+        key=lambda x: x["openings"],
+        reverse=True
+    )[:20]
+
+    # Job type distribution
+    job_types = jobs_df["job_type"].value_counts().to_dict() if "job_type" in jobs_df else {}
+
+    # Remote analysis
+    remote_count = jobs_df["is_remote"].sum() if "is_remote" in jobs_df else 0
+
+    # Salary analysis
+    salary_data = []
+    for _, job in jobs_df.iterrows():
+        if job.get("min_amount") and job.get("max_amount"):
+            salary_data.append({
+                "min": job["min_amount"],
+                "max": job["max_amount"],
+                "interval": job.get("interval", "yearly")
+            })
+
+    return {
+        "success": True,
+        "count": len(jobs_df),
+        "analysis_date": datetime.now().isoformat(),
+        "search_params": {
+            "search_term": search_term,
+            "location": location
+        },
+        "top_hiring_companies": top_companies,
+        "job_type_distribution": job_types,
+        "remote_positions": {
+            "count": int(remote_count),
+            "percentage": round(remote_count / len(jobs_df) * 100, 1) if len(jobs_df) > 0 else 0
+        },
+        "salary_data_points": len(salary_data),
+        "unique_companies": len(company_counts)
+    }
+
+
+def monitor_target_accounts(target_companies: list, search_term: str = "") -> dict:
+    """
+    Monitor specific target accounts for their job postings.
+    Useful for BD teams tracking key prospects.
+
+    Args:
+        target_companies: List of company names to monitor
+        search_term: Optional filter for specific roles
+
+    Returns:
+        Analysis of each target company's hiring activity
+    """
+
+    results = []
+
+    for company in target_companies:
+        # Combine company name with search term for more targeted results
+        query = f'"{company}" {search_term}'.strip()
+
+        jobs_df = scrape_jobs(
+            site_name=["indeed"],
+            search_term=query,
+            results_wanted=30,
+            country_indeed="usa",
+            verbose=0
+        )
+
+        # Filter to ensure company match
+        company_jobs = jobs_df[
+            jobs_df["company"].str.contains(company, case=False, na=False)
+        ] if not jobs_df.empty else jobs_df
+
+        if not company_jobs.empty:
+            roles = company_jobs["title"].tolist()
+            locations = company_jobs["location"].unique().tolist()
+
+            results.append({
+                "company": company,
+                "openings_found": len(company_jobs),
+                "sample_roles": roles[:10],
+                "hiring_locations": locations,
+                "growth_signal": "HIGH" if len(company_jobs) > 10 else "MEDIUM" if len(company_jobs) > 3 else "LOW"
+            })
+        else:
+            results.append({
+                "company": company,
+                "openings_found": 0,
+                "growth_signal": "NONE"
+            })
+
+    return {
+        "success": True,
+        "monitored_companies": len(target_companies),
+        "companies_with_openings": sum(1 for r in results if r["openings_found"] > 0),
+        "results": results
+    }
+
+
+def find_opportunities_by_keywords(keywords: list, location: str = "") -> dict:
+    """
+    Search for BD opportunities based on specific keywords.
+    Useful for finding companies with specific needs/projects.
+
+    Args:
+        keywords: List of keywords indicating opportunity (e.g., ["cloud migration", "modernization"])
+        location: Geographic filter
+
+    Returns:
+        Companies and roles matching the keywords
+    """
+
+    all_opportunities = []
+
+    for keyword in keywords:
+        jobs_df = scrape_jobs(
+            site_name=["indeed", "linkedin"],
+            search_term=keyword,
+            location=location,
+            results_wanted=25,
+            hours_old=168,  # Last week
+            country_indeed="usa",
+            verbose=0
+        )
+
+        for _, job in jobs_df.iterrows():
+            all_opportunities.append({
+                "keyword": keyword,
+                "company": job.get("company"),
+                "title": job.get("title"),
+                "location": job.get("location"),
+                "job_url": job.get("job_url"),
+                "description_preview": str(job.get("description", ""))[:300] if job.get("description") else None
+            })
+
+    # Group by company
+    company_opportunities = defaultdict(list)
+    for opp in all_opportunities:
+        company_opportunities[opp["company"]].append(opp)
+
+    # Score companies by keyword coverage
+    scored_companies = [
+        {
+            "company": company,
+            "total_matches": len(opps),
+            "keywords_matched": list(set(o["keyword"] for o in opps)),
+            "opportunities": opps
+        }
+        for company, opps in company_opportunities.items()
+    ]
+
+    scored_companies.sort(key=lambda x: len(x["keywords_matched"]), reverse=True)
+
+    return {
+        "success": True,
+        "keywords_searched": keywords,
+        "total_opportunities": len(all_opportunities),
+        "unique_companies": len(company_opportunities),
+        "top_opportunities": scored_companies[:15]
+    }
+
+
+if __name__ == "__main__":
+    print("=== BD Intelligence Job Analysis ===\n")
+
+    # Example 1: Analyze hiring trends for cloud engineers
+    print("1. Analyzing hiring trends for 'cloud engineer'...")
+    trends = analyze_hiring_trends("cloud engineer", "Remote", results_wanted=50)
+    print(f"   Found {trends['count']} jobs across {trends['unique_companies']} companies")
+    print(f"   Top hiring: {[c['company'] for c in trends['top_hiring_companies'][:5]]}")
+
+    # Example 2: Monitor target accounts
+    print("\n2. Monitoring target accounts...")
+    targets = ["Amazon", "Google", "Microsoft", "Booz Allen", "Leidos"]
+    monitor_result = monitor_target_accounts(targets, "engineer")
+    for r in monitor_result["results"]:
+        print(f"   {r['company']}: {r['openings_found']} openings ({r['growth_signal']} signal)")
+
+    # Example 3: Find opportunities by keywords
+    print("\n3. Searching for BD opportunities...")
+    opportunity_keywords = ["cloud migration", "digital transformation", "modernization"]
+    opportunities = find_opportunities_by_keywords(opportunity_keywords, "DC")
+    print(f"   Found {opportunities['total_opportunities']} matches across {opportunities['unique_companies']} companies")
+
+    # Save full results
+    full_results = {
+        "trends": trends,
+        "target_monitoring": monitor_result,
+        "opportunities": opportunities
+    }
+
+    with open("bd_intelligence_report.json", "w") as f:
+        json.dump(full_results, f, indent=2, default=str)
+
+    print("\nFull report saved to bd_intelligence_report.json")

--- a/examples/federal_contractor_search.py
+++ b/examples/federal_contractor_search.py
@@ -1,0 +1,156 @@
+"""
+Federal Contractor Job Search Example
+
+This example demonstrates searching for jobs at federal contractors and
+defense-related positions - useful for CIS labor category mapping and
+BD intelligence gathering.
+
+Usage:
+    python examples/federal_contractor_search.py
+"""
+
+from jobspy import scrape_jobs
+import json
+
+
+def search_federal_contractor_jobs():
+    """
+    Search for jobs at major federal contractors and defense companies.
+    Useful for BD teams tracking competitor hiring and market intelligence.
+    """
+
+    # Search terms relevant to federal/defense contracting
+    search_queries = [
+        {
+            "term": "security clearance",
+            "location": "Washington, DC",
+            "description": "Cleared positions in DC area"
+        },
+        {
+            "term": "program manager government",
+            "location": "Virginia",
+            "description": "Government PM roles"
+        },
+        {
+            "term": "systems engineer TS/SCI",
+            "location": "Remote",
+            "description": "Cleared systems engineers"
+        }
+    ]
+
+    all_results = []
+
+    for query in search_queries:
+        print(f"\nSearching: {query['description']}...")
+
+        jobs = scrape_jobs(
+            site_name=["indeed", "linkedin"],
+            search_term=query["term"],
+            location=query["location"],
+            results_wanted=15,
+            hours_old=168,  # Last week
+            country_indeed="usa",
+            linkedin_fetch_description=False,  # Set True for full descriptions
+            verbose=0
+        )
+
+        # Add query context to results
+        for _, job in jobs.iterrows():
+            job_dict = job.to_dict()
+            job_dict["search_query"] = query["term"]
+            job_dict["query_location"] = query["location"]
+            all_results.append(job_dict)
+
+        print(f"  Found {len(jobs)} jobs")
+
+    # Summary by company (useful for BD intelligence)
+    companies = {}
+    for job in all_results:
+        company = job.get("company", "Unknown")
+        if company not in companies:
+            companies[company] = {"count": 0, "roles": []}
+        companies[company]["count"] += 1
+        companies[company]["roles"].append(job.get("title", "N/A"))
+
+    # Sort by hiring volume
+    top_hiring = sorted(companies.items(), key=lambda x: x[1]["count"], reverse=True)[:10]
+
+    print("\n=== Top Hiring Companies ===")
+    for company, data in top_hiring:
+        print(f"{company}: {data['count']} openings")
+
+    return {
+        "success": True,
+        "total_jobs": len(all_results),
+        "companies_found": len(companies),
+        "top_hiring": dict(top_hiring),
+        "jobs": all_results
+    }
+
+
+def search_competitor_staffing_companies():
+    """
+    Search for jobs posted by competitor staffing companies.
+    These are the staffing agencies you provided as competitors.
+    """
+
+    # Competitor staffing companies to monitor
+    competitors = [
+        "Insight Global",
+        "TEKsystems",
+        "Apex Systems",
+        "Belcan",
+        "GDIT",
+        "Booz Allen Hamilton",
+        "Leidos",
+        "SAIC",
+        "ManTech",
+        "Peraton"
+    ]
+
+    all_results = []
+
+    for company in competitors:
+        print(f"\nSearching jobs at: {company}...")
+
+        # Search for company name in job postings
+        jobs = scrape_jobs(
+            site_name=["indeed"],
+            search_term=f'"{company}"',  # Exact company match
+            location="",  # All locations
+            results_wanted=20,
+            country_indeed="usa",
+            verbose=0
+        )
+
+        for _, job in jobs.iterrows():
+            job_dict = job.to_dict()
+            job_dict["target_company"] = company
+            all_results.append(job_dict)
+
+        print(f"  Found {len(jobs)} jobs")
+
+    return {
+        "success": True,
+        "total_jobs": len(all_results),
+        "competitors_searched": len(competitors),
+        "jobs": all_results
+    }
+
+
+if __name__ == "__main__":
+    print("=== Federal Contractor Job Search ===")
+    result = search_federal_contractor_jobs()
+
+    print("\n" + "="*50)
+    print("\n=== Competitor Staffing Company Search ===")
+    competitor_result = search_competitor_staffing_companies()
+
+    # Save results to JSON files
+    with open("federal_jobs.json", "w") as f:
+        json.dump(result, f, indent=2, default=str)
+
+    with open("competitor_jobs.json", "w") as f:
+        json.dump(competitor_result, f, indent=2, default=str)
+
+    print("\nResults saved to federal_jobs.json and competitor_jobs.json")

--- a/examples/json_output_example.py
+++ b/examples/json_output_example.py
@@ -1,0 +1,171 @@
+"""
+JSON Output Example for LLM Integration
+
+This example shows how to get job results in JSON format,
+which is ideal for ChatGPT and other LLMs to parse and process.
+
+Usage:
+    python examples/json_output_example.py
+
+For ChatGPT:
+    When asked to search for jobs, use this pattern to return
+    structured JSON that can be easily parsed and analyzed.
+"""
+
+from jobspy import scrape_jobs
+import json
+import sys
+
+
+def search_jobs_json(
+    search_term: str,
+    location: str = "",
+    sites: list = None,
+    results_wanted: int = 15,
+    hours_old: int = None,
+    remote_only: bool = False,
+    job_type: str = None,
+    fields: list = None
+) -> dict:
+    """
+    Search for jobs and return results as a JSON-serializable dictionary.
+
+    This function is designed for easy integration with ChatGPT and other LLMs.
+    All parameters have sensible defaults and the output is always valid JSON.
+
+    Args:
+        search_term: Job title or keywords to search for
+        location: Location (city, state) or "Remote" for remote jobs
+        sites: List of job sites ["indeed", "linkedin", "glassdoor", etc.]
+        results_wanted: Number of results per site (default: 15)
+        hours_old: Only jobs posted within N hours (optional)
+        remote_only: If True, only return remote jobs
+        job_type: Filter by type - "fulltime", "parttime", "contract", "internship"
+        fields: List of fields to include in output (optional, returns all if None)
+
+    Returns:
+        dict: {
+            "success": bool,
+            "count": int,
+            "search_params": dict,
+            "jobs": list[dict]
+        }
+
+    Example:
+        >>> result = search_jobs_json("python developer", "NYC", results_wanted=5)
+        >>> print(result["count"])
+        5
+        >>> for job in result["jobs"]:
+        ...     print(f"{job['title']} at {job['company']}")
+    """
+
+    if sites is None:
+        sites = ["indeed", "linkedin"]
+
+    # Default fields for LLM consumption (most useful fields)
+    default_fields = [
+        "site", "title", "company", "location", "job_type",
+        "min_amount", "max_amount", "interval", "currency",
+        "date_posted", "job_url", "is_remote", "description"
+    ]
+
+    output_fields = fields if fields else default_fields
+
+    try:
+        jobs_df = scrape_jobs(
+            site_name=sites,
+            search_term=search_term,
+            location=location,
+            results_wanted=results_wanted,
+            hours_old=hours_old,
+            is_remote=remote_only,
+            job_type=job_type,
+            country_indeed="usa",
+            verbose=0
+        )
+
+        # Convert to list of dicts
+        jobs_list = jobs_df.to_dict(orient="records")
+
+        # Filter to requested fields
+        if fields:
+            jobs_list = [
+                {k: v for k, v in job.items() if k in output_fields}
+                for job in jobs_list
+            ]
+
+        return {
+            "success": True,
+            "count": len(jobs_list),
+            "search_params": {
+                "search_term": search_term,
+                "location": location,
+                "sites": sites,
+                "results_wanted": results_wanted,
+                "hours_old": hours_old,
+                "remote_only": remote_only,
+                "job_type": job_type
+            },
+            "jobs": jobs_list
+        }
+
+    except Exception as e:
+        return {
+            "success": False,
+            "error": str(e),
+            "count": 0,
+            "jobs": []
+        }
+
+
+def print_json_result(result: dict, pretty: bool = True):
+    """Print result as JSON to stdout."""
+    if pretty:
+        print(json.dumps(result, indent=2, default=str))
+    else:
+        print(json.dumps(result, default=str))
+
+
+# Example usage patterns for ChatGPT
+CHATGPT_EXAMPLES = """
+=== ChatGPT Usage Examples ===
+
+1. Basic Search:
+   result = search_jobs_json("data scientist", "Boston, MA", results_wanted=10)
+
+2. Remote Jobs Only:
+   result = search_jobs_json("software engineer", remote_only=True, results_wanted=20)
+
+3. Recent Contract Jobs:
+   result = search_jobs_json("project manager", "DC", job_type="contract", hours_old=24)
+
+4. Multi-Site Search:
+   result = search_jobs_json("DevOps", "Seattle",
+                            sites=["indeed", "linkedin", "glassdoor"])
+
+5. Specific Fields Only:
+   result = search_jobs_json("analyst", fields=["title", "company", "job_url"])
+
+6. Process Results:
+   result = search_jobs_json("python developer")
+   for job in result["jobs"]:
+       print(f"[{job['site']}] {job['title']} at {job['company']}")
+       print(f"  URL: {job['job_url']}")
+"""
+
+
+if __name__ == "__main__":
+    # Example: Search for Python developers
+    print("Searching for Python developer jobs...\n")
+
+    result = search_jobs_json(
+        search_term="python developer",
+        location="Remote",
+        sites=["indeed", "linkedin"],
+        results_wanted=5,
+        hours_old=72
+    )
+
+    print_json_result(result)
+
+    print("\n" + CHATGPT_EXAMPLES)

--- a/jobspy/__init__.py
+++ b/jobspy/__init__.py
@@ -52,8 +52,113 @@ def scrape_jobs(
     **kwargs,
 ) -> pd.DataFrame:
     """
-    Scrapes job data from job boards concurrently
-    :return: Pandas DataFrame containing job data
+    Scrape job postings from multiple job boards concurrently.
+
+    This is the main entry point for JobSpy. It searches specified job boards
+    in parallel and returns aggregated results as a pandas DataFrame.
+
+    Args:
+        site_name: Job board(s) to search. Options: "linkedin", "indeed",
+            "zip_recruiter", "glassdoor", "google", "bayt", "naukri".
+            Can be a single string, list of strings, or Site enum(s).
+            Default: all supported sites.
+
+        search_term: Job title, keywords, or skills to search for.
+            Supports Boolean operators for Indeed (AND, OR, -, "exact match").
+            Example: '"software engineer" python -junior'
+
+        google_search_term: Custom search term specifically for Google Jobs.
+            Use exact syntax from Google Jobs search box for best results.
+
+        location: Geographic location (city, state/province, country) or "Remote".
+            Examples: "San Francisco, CA", "New York, NY", "Remote", "London, UK"
+
+        distance: Search radius in miles from location. Default: 50.
+
+        is_remote: If True, filter for remote jobs only. Default: False.
+
+        job_type: Filter by employment type. Options: "fulltime", "parttime",
+            "internship", "contract". Default: None (all types).
+
+        easy_apply: Filter for easy apply jobs (site-hosted applications).
+            Note: LinkedIn easy apply filter may not work reliably.
+
+        results_wanted: Number of job results to retrieve per site. Default: 15.
+            Max ~1000 per search due to job board limitations.
+
+        country_indeed: Country code for Indeed/Glassdoor searches.
+            Default: "usa". See README for full list of supported countries.
+
+        proxies: List of proxy servers for avoiding rate limits.
+            Format: ["user:pass@host:port", "host:port", "localhost"].
+            Recommended for LinkedIn scraping.
+
+        ca_cert: Path to CA certificate file for proxy SSL verification.
+
+        description_format: Format for job descriptions. Options: "markdown", "html".
+            Default: "markdown".
+
+        linkedin_fetch_description: If True, fetch full descriptions for LinkedIn
+            jobs. Slower but provides more detail. Default: False.
+
+        linkedin_company_ids: List of LinkedIn company IDs to search.
+            Useful for targeting specific companies on LinkedIn.
+
+        offset: Start search from this result number. Default: 0.
+            Useful for pagination through large result sets.
+
+        hours_old: Filter jobs posted within the last N hours.
+            Examples: 24 (last day), 72 (last 3 days), 168 (last week).
+
+        enforce_annual_salary: If True, convert all salaries to annual.
+            Default: False.
+
+        verbose: Logging verbosity. 0=errors only, 1=warnings, 2=all. Default: 0.
+
+    Returns:
+        pd.DataFrame: DataFrame containing job postings with columns:
+            - site: Source job board
+            - title: Job title
+            - company: Company name
+            - location: Job location
+            - job_type: Employment type (fulltime, parttime, etc.)
+            - min_amount, max_amount: Salary range
+            - interval: Salary period (yearly, hourly, etc.)
+            - currency: Salary currency
+            - date_posted: When job was posted
+            - job_url: URL to job posting
+            - description: Job description (markdown format)
+            - is_remote: Whether job is remote
+            - company_url: Company website
+            - And additional site-specific fields
+
+    Example:
+        >>> from jobspy import scrape_jobs
+        >>> import json
+        >>>
+        >>> # Basic search
+        >>> jobs = scrape_jobs(
+        ...     site_name=["indeed", "linkedin"],
+        ...     search_term="python developer",
+        ...     location="San Francisco, CA",
+        ...     results_wanted=10
+        ... )
+        >>> print(f"Found {len(jobs)} jobs")
+        >>>
+        >>> # Convert to JSON for LLM processing
+        >>> result = jobs.to_dict(orient="records")
+        >>> print(json.dumps(result, indent=2, default=str))
+
+    Notes:
+        - Indeed is recommended as primary source (no rate limiting)
+        - LinkedIn requires proxies for sustained use (rate limiting)
+        - Results are sorted by site and date_posted (newest first)
+        - Empty DataFrame returned if no jobs found
+
+    See Also:
+        - CHATGPT_GUIDE.md for LLM integration examples
+        - tool_manifest.json for machine-readable API documentation
+        - examples/ directory for usage patterns
     """
     SCRAPER_MAPPING = {
         Site.LINKEDIN: LinkedIn,

--- a/jobspy_cli.py
+++ b/jobspy_cli.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""
+JobSpy CLI - Command-line interface for ChatGPT and LLM integration.
+
+This CLI wrapper enables ChatGPT and other LLMs to invoke JobSpy for job searches
+via command-line execution with JSON input/output for easy parsing.
+
+Usage Examples:
+    # Basic search
+    python jobspy_cli.py --search "software engineer" --location "San Francisco, CA"
+
+    # Search specific sites with JSON output
+    python jobspy_cli.py --search "data analyst" --sites indeed,linkedin --format json
+
+    # Full search with all options
+    python jobspy_cli.py --search "project manager" --location "Remote" --sites indeed,linkedin,glassdoor --results 25 --hours 48 --format json
+
+    # JSON input mode (for programmatic use)
+    echo '{"search_term": "python developer", "location": "NYC"}' | python jobspy_cli.py --json-input
+"""
+
+import argparse
+import json
+import sys
+import csv
+from io import StringIO
+from typing import Optional
+
+try:
+    from jobspy import scrape_jobs
+except ImportError:
+    print(json.dumps({
+        "error": "JobSpy not installed. Run: pip install python-jobspy",
+        "success": False
+    }))
+    sys.exit(1)
+
+
+def parse_args():
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="JobSpy CLI - Search multiple job boards with one command",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  %(prog)s --search "software engineer" --location "NYC"
+  %(prog)s --search "data analyst" --sites indeed,linkedin --format json
+  %(prog)s --json-input < params.json
+
+Supported Sites:
+  indeed, linkedin, zip_recruiter, glassdoor, google, bayt, naukri
+
+Output Formats:
+  json    - JSON array of job objects (default for LLM use)
+  csv     - CSV formatted output
+  table   - Human-readable table format
+  summary - Condensed summary with key fields only
+        """
+    )
+
+    # Search parameters
+    parser.add_argument("--search", "-s", type=str, help="Search term/job title")
+    parser.add_argument("--location", "-l", type=str, help="Job location (city, state, or 'Remote')")
+    parser.add_argument("--sites", type=str, default="indeed,linkedin",
+                       help="Comma-separated list of sites to search (default: indeed,linkedin)")
+    parser.add_argument("--results", "-n", type=int, default=15,
+                       help="Number of results per site (default: 15)")
+    parser.add_argument("--hours", type=int, help="Only jobs posted within N hours")
+    parser.add_argument("--distance", type=int, default=50, help="Search radius in miles (default: 50)")
+    parser.add_argument("--remote", action="store_true", help="Filter for remote jobs only")
+    parser.add_argument("--job-type", type=str, choices=["fulltime", "parttime", "internship", "contract"],
+                       help="Filter by job type")
+    parser.add_argument("--country", type=str, default="usa", help="Country for Indeed/Glassdoor (default: usa)")
+
+    # LinkedIn specific
+    parser.add_argument("--linkedin-descriptions", action="store_true",
+                       help="Fetch full descriptions for LinkedIn jobs (slower)")
+    parser.add_argument("--linkedin-company-ids", type=str,
+                       help="Comma-separated LinkedIn company IDs to search")
+
+    # Output options
+    parser.add_argument("--format", "-f", type=str, default="json",
+                       choices=["json", "csv", "table", "summary"],
+                       help="Output format (default: json)")
+    parser.add_argument("--output", "-o", type=str, help="Output file path (default: stdout)")
+    parser.add_argument("--fields", type=str,
+                       help="Comma-separated list of fields to include in output")
+    parser.add_argument("--pretty", action="store_true", help="Pretty-print JSON output")
+
+    # Advanced options
+    parser.add_argument("--proxies", type=str, help="Comma-separated list of proxy servers")
+    parser.add_argument("--google-search-term", type=str,
+                       help="Custom search term for Google Jobs (use exact Google Jobs syntax)")
+    parser.add_argument("--verbose", "-v", type=int, default=0, choices=[0, 1, 2],
+                       help="Verbosity level (0=errors, 1=warnings, 2=all)")
+
+    # JSON input mode
+    parser.add_argument("--json-input", action="store_true",
+                       help="Read search parameters from JSON on stdin")
+
+    # Utility commands
+    parser.add_argument("--list-sites", action="store_true", help="List all supported job sites")
+    parser.add_argument("--list-countries", action="store_true", help="List supported countries")
+    parser.add_argument("--version", action="store_true", help="Show version info")
+
+    return parser.parse_args()
+
+
+def format_output(jobs_df, format_type: str, fields: Optional[list] = None, pretty: bool = False) -> str:
+    """Format job results for output."""
+    if jobs_df.empty:
+        if format_type == "json":
+            return json.dumps({"jobs": [], "count": 0, "success": True})
+        return "No jobs found."
+
+    # Filter fields if specified
+    if fields:
+        available_fields = [f for f in fields if f in jobs_df.columns]
+        if available_fields:
+            jobs_df = jobs_df[available_fields]
+
+    if format_type == "json":
+        # Convert to list of dicts for JSON
+        jobs_list = jobs_df.to_dict(orient="records")
+        result = {
+            "jobs": jobs_list,
+            "count": len(jobs_list),
+            "success": True
+        }
+        if pretty:
+            return json.dumps(result, indent=2, default=str)
+        return json.dumps(result, default=str)
+
+    elif format_type == "csv":
+        output = StringIO()
+        jobs_df.to_csv(output, index=False, quoting=csv.QUOTE_NONNUMERIC)
+        return output.getvalue()
+
+    elif format_type == "table":
+        # Simple table format
+        key_cols = ["site", "title", "company", "location", "job_url"]
+        display_cols = [c for c in key_cols if c in jobs_df.columns]
+        return jobs_df[display_cols].to_string(index=False)
+
+    elif format_type == "summary":
+        # Condensed summary for quick overview
+        summary_lines = [f"Found {len(jobs_df)} jobs:\n"]
+        for _, job in jobs_df.iterrows():
+            title = job.get("title", "N/A")
+            company = job.get("company", "N/A")
+            location = job.get("location", "N/A")
+            site = job.get("site", "N/A")
+            summary_lines.append(f"- [{site}] {title} at {company} ({location})")
+        return "\n".join(summary_lines)
+
+    return str(jobs_df)
+
+
+def run_search(params: dict) -> str:
+    """Execute job search with given parameters."""
+    try:
+        # Parse sites
+        sites = params.get("sites", "indeed,linkedin")
+        if isinstance(sites, str):
+            sites = [s.strip() for s in sites.split(",")]
+
+        # Parse proxies
+        proxies = params.get("proxies")
+        if isinstance(proxies, str):
+            proxies = [p.strip() for p in proxies.split(",")]
+
+        # Parse LinkedIn company IDs
+        company_ids = params.get("linkedin_company_ids")
+        if isinstance(company_ids, str):
+            company_ids = [int(id.strip()) for id in company_ids.split(",")]
+
+        # Execute search
+        jobs_df = scrape_jobs(
+            site_name=sites,
+            search_term=params.get("search_term") or params.get("search"),
+            google_search_term=params.get("google_search_term"),
+            location=params.get("location"),
+            distance=params.get("distance", 50),
+            is_remote=params.get("remote", False) or params.get("is_remote", False),
+            job_type=params.get("job_type"),
+            results_wanted=params.get("results", 15) or params.get("results_wanted", 15),
+            hours_old=params.get("hours") or params.get("hours_old"),
+            country_indeed=params.get("country", "usa") or params.get("country_indeed", "usa"),
+            proxies=proxies,
+            linkedin_fetch_description=params.get("linkedin_descriptions", False) or params.get("linkedin_fetch_description", False),
+            linkedin_company_ids=company_ids,
+            verbose=params.get("verbose", 0),
+        )
+
+        # Format output
+        format_type = params.get("format", "json")
+        fields = params.get("fields")
+        if isinstance(fields, str):
+            fields = [f.strip() for f in fields.split(",")]
+
+        return format_output(jobs_df, format_type, fields, params.get("pretty", False))
+
+    except Exception as e:
+        error_response = {
+            "error": str(e),
+            "success": False,
+            "hint": "Check your search parameters and try again. Use --help for usage info."
+        }
+        return json.dumps(error_response, indent=2)
+
+
+def list_sites():
+    """List all supported job sites."""
+    sites = {
+        "indeed": "Indeed.com - Best coverage, no rate limiting",
+        "linkedin": "LinkedIn Jobs - Requires proxies for best results",
+        "zip_recruiter": "ZipRecruiter - US/Canada only",
+        "glassdoor": "Glassdoor - Includes company reviews",
+        "google": "Google Jobs - Aggregates from multiple sources",
+        "bayt": "Bayt.com - Middle East job board",
+        "naukri": "Naukri.com - India job board"
+    }
+    return json.dumps({"sites": sites, "default": ["indeed", "linkedin"]}, indent=2)
+
+
+def list_countries():
+    """List supported countries for Indeed/Glassdoor."""
+    countries = [
+        "usa", "uk", "canada", "australia", "germany", "france", "india",
+        "netherlands", "spain", "italy", "brazil", "mexico", "japan",
+        "singapore", "hong kong", "new zealand", "ireland", "belgium",
+        "switzerland", "austria", "poland", "czech republic", "sweden",
+        "norway", "denmark", "finland", "portugal", "greece", "turkey",
+        "south africa", "united arab emirates", "saudi arabia", "egypt",
+        "nigeria", "pakistan", "philippines", "malaysia", "thailand",
+        "vietnam", "indonesia", "south korea", "taiwan", "china"
+    ]
+    return json.dumps({
+        "countries": countries,
+        "note": "Use exact spelling for country_indeed parameter",
+        "glassdoor_supported": ["usa", "uk", "canada", "australia", "germany", "france", "india", "netherlands", "spain", "italy", "brazil", "mexico", "singapore", "hong kong", "new zealand", "ireland", "belgium", "switzerland"]
+    }, indent=2)
+
+
+def main():
+    """Main entry point."""
+    args = parse_args()
+
+    # Handle utility commands
+    if args.version:
+        print(json.dumps({"name": "JobSpy CLI", "version": "1.0.0", "library": "python-jobspy"}))
+        return
+
+    if args.list_sites:
+        print(list_sites())
+        return
+
+    if args.list_countries:
+        print(list_countries())
+        return
+
+    # Handle JSON input mode
+    if args.json_input:
+        try:
+            input_data = sys.stdin.read()
+            params = json.loads(input_data)
+        except json.JSONDecodeError as e:
+            print(json.dumps({"error": f"Invalid JSON input: {e}", "success": False}))
+            sys.exit(1)
+    else:
+        # Build params from command-line args
+        if not args.search:
+            print(json.dumps({
+                "error": "Search term required. Use --search 'job title' or --json-input",
+                "success": False,
+                "usage": "python jobspy_cli.py --search 'software engineer' --location 'NYC'"
+            }))
+            sys.exit(1)
+
+        params = {
+            "search_term": args.search,
+            "location": args.location,
+            "sites": args.sites,
+            "results": args.results,
+            "hours": args.hours,
+            "distance": args.distance,
+            "remote": args.remote,
+            "job_type": args.job_type,
+            "country": args.country,
+            "linkedin_descriptions": args.linkedin_descriptions,
+            "linkedin_company_ids": args.linkedin_company_ids,
+            "google_search_term": args.google_search_term,
+            "proxies": args.proxies,
+            "verbose": args.verbose,
+            "format": args.format,
+            "fields": args.fields,
+            "pretty": args.pretty,
+        }
+
+    # Run search
+    result = run_search(params)
+
+    # Output results
+    if args.output:
+        with open(args.output, "w") as f:
+            f.write(result)
+        print(json.dumps({"success": True, "output_file": args.output}))
+    else:
+        print(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/tool_manifest.json
+++ b/tool_manifest.json
@@ -1,0 +1,217 @@
+{
+  "name": "JobSpy",
+  "version": "1.1.80",
+  "description": "Multi-source job board scraper that aggregates job postings from LinkedIn, Indeed, Glassdoor, ZipRecruiter, Google Jobs, Bayt, and Naukri into structured data",
+  "repository": "https://github.com/DirtyDiablo/JobSpy",
+  "keywords": [
+    "job-search",
+    "job-scraping",
+    "linkedin",
+    "indeed",
+    "glassdoor",
+    "ziprecruiter",
+    "google-jobs",
+    "employment",
+    "hiring",
+    "bd-intelligence",
+    "market-research"
+  ],
+  "capabilities": [
+    "multi_site_job_search",
+    "concurrent_scraping",
+    "structured_data_output",
+    "proxy_support",
+    "salary_extraction",
+    "remote_job_filtering"
+  ],
+  "tools": [
+    {
+      "name": "job_search",
+      "description": "Search for job postings across multiple job boards simultaneously. Returns structured job data including title, company, location, salary, and job URL.",
+      "function": "scrape_jobs",
+      "module": "jobspy",
+      "cli": "python jobspy_cli.py",
+      "inputs": {
+        "search_term": {
+          "type": "string",
+          "required": true,
+          "description": "Job title, keywords, or skills to search for. Supports Boolean operators (AND, OR) and exact match with quotes."
+        },
+        "location": {
+          "type": "string",
+          "required": false,
+          "description": "Geographic location (city, state) or 'Remote' for remote positions",
+          "examples": ["San Francisco, CA", "New York, NY", "Remote", "Washington, DC"]
+        },
+        "site_name": {
+          "type": "array",
+          "required": false,
+          "default": ["indeed", "linkedin"],
+          "description": "List of job boards to search",
+          "enum": ["indeed", "linkedin", "zip_recruiter", "glassdoor", "google", "bayt", "naukri"]
+        },
+        "results_wanted": {
+          "type": "integer",
+          "required": false,
+          "default": 15,
+          "description": "Number of job results to retrieve per site (max ~1000)"
+        },
+        "hours_old": {
+          "type": "integer",
+          "required": false,
+          "description": "Filter jobs posted within the last N hours",
+          "examples": [24, 48, 72, 168]
+        },
+        "is_remote": {
+          "type": "boolean",
+          "required": false,
+          "default": false,
+          "description": "Filter for remote jobs only"
+        },
+        "job_type": {
+          "type": "string",
+          "required": false,
+          "description": "Filter by employment type",
+          "enum": ["fulltime", "parttime", "internship", "contract"]
+        },
+        "distance": {
+          "type": "integer",
+          "required": false,
+          "default": 50,
+          "description": "Search radius in miles from the specified location"
+        },
+        "country_indeed": {
+          "type": "string",
+          "required": false,
+          "default": "usa",
+          "description": "Country for Indeed/Glassdoor searches"
+        },
+        "linkedin_fetch_description": {
+          "type": "boolean",
+          "required": false,
+          "default": false,
+          "description": "Fetch full job descriptions for LinkedIn (slower but more detailed)"
+        },
+        "proxies": {
+          "type": "array",
+          "required": false,
+          "description": "List of proxy servers for avoiding rate limits"
+        }
+      },
+      "outputs": {
+        "type": "object",
+        "properties": {
+          "jobs": {
+            "type": "array",
+            "description": "List of job postings",
+            "items": {
+              "type": "object",
+              "properties": {
+                "site": "string - Source job board",
+                "title": "string - Job title",
+                "company": "string - Company name",
+                "location": "string - Job location",
+                "job_type": "string - Employment type",
+                "min_amount": "number - Minimum salary",
+                "max_amount": "number - Maximum salary",
+                "interval": "string - Salary period (yearly, hourly, etc.)",
+                "currency": "string - Salary currency",
+                "date_posted": "string - Date job was posted",
+                "job_url": "string - URL to job posting",
+                "description": "string - Job description (markdown format)",
+                "is_remote": "boolean - Whether job is remote",
+                "company_url": "string - Company website URL",
+                "company_industry": "string - Industry classification"
+              }
+            }
+          },
+          "count": {
+            "type": "integer",
+            "description": "Total number of jobs found"
+          }
+        }
+      },
+      "examples": [
+        {
+          "description": "Search for Python developers in NYC",
+          "python": "from jobspy import scrape_jobs\njobs = scrape_jobs(search_term='python developer', location='New York, NY', results_wanted=10)",
+          "cli": "python jobspy_cli.py --search 'python developer' --location 'New York, NY' --results 10 --format json"
+        },
+        {
+          "description": "Find remote data analyst jobs posted in last 24 hours",
+          "python": "jobs = scrape_jobs(search_term='data analyst', is_remote=True, hours_old=24, results_wanted=20)",
+          "cli": "python jobspy_cli.py --search 'data analyst' --remote --hours 24 --results 20"
+        },
+        {
+          "description": "Search Indeed and Glassdoor for PM jobs",
+          "python": "jobs = scrape_jobs(site_name=['indeed', 'glassdoor'], search_term='project manager', location='DC', results_wanted=25)",
+          "cli": "python jobspy_cli.py --search 'project manager' --sites indeed,glassdoor --location 'DC' --results 25"
+        }
+      ]
+    },
+    {
+      "name": "list_supported_sites",
+      "description": "Get list of all supported job board sites",
+      "cli": "python jobspy_cli.py --list-sites",
+      "outputs": {
+        "sites": {
+          "indeed": "Indeed.com - Best coverage, no rate limiting",
+          "linkedin": "LinkedIn Jobs - Requires proxies for best results",
+          "zip_recruiter": "ZipRecruiter - US/Canada only",
+          "glassdoor": "Glassdoor - Includes company reviews",
+          "google": "Google Jobs - Aggregates from multiple sources",
+          "bayt": "Bayt.com - Middle East job board",
+          "naukri": "Naukri.com - India job board"
+        }
+      }
+    },
+    {
+      "name": "list_supported_countries",
+      "description": "Get list of supported countries for Indeed/Glassdoor",
+      "cli": "python jobspy_cli.py --list-countries"
+    }
+  ],
+  "use_cases": {
+    "bd_intelligence": {
+      "description": "Business Development intelligence gathering through job market analysis",
+      "examples": [
+        "Monitor competitor hiring patterns",
+        "Identify companies with growth signals (high hiring volume)",
+        "Track specific target accounts for BD opportunities",
+        "Analyze market demand for specific skills"
+      ]
+    },
+    "market_research": {
+      "description": "Labor market research and analysis",
+      "examples": [
+        "Salary benchmarking for specific roles",
+        "Geographic distribution of job opportunities",
+        "Skills demand analysis",
+        "Industry hiring trends"
+      ]
+    },
+    "cis_mapping": {
+      "description": "CIS labor category mapping from job descriptions",
+      "examples": [
+        "Extract role duties and qualifications",
+        "Match job descriptions to labor categories",
+        "Identify clearance requirements"
+      ]
+    }
+  },
+  "chatgpt_integration": {
+    "recommended_approach": "Use the CLI wrapper (jobspy_cli.py) for ChatGPT code execution",
+    "output_format": "JSON is recommended for LLM parsing",
+    "rate_limiting_notes": "Indeed has no rate limiting. LinkedIn requires proxies for sustained use.",
+    "best_practices": [
+      "Start with Indeed for reliable results",
+      "Use hours_old to get recent postings",
+      "Request JSON format for structured output",
+      "Limit results_wanted to 20-50 for quick responses"
+    ]
+  },
+  "installation": {
+    "pip": "pip install python-jobspy",
+    "requirements": "Python 3.10+"
+  }
+}


### PR DESCRIPTION
This adds comprehensive tooling and documentation to enable ChatGPT and other LLMs to effectively use JobSpy for job market research, BD intelligence gathering, and automated job searches.

New files:
- jobspy_cli.py: CLI wrapper with JSON input/output for LLM code execution
- CHATGPT_GUIDE.md: Complete integration guide with prompt templates
- tool_manifest.json: Machine-readable tool metadata for MCP servers
- examples/: Ready-to-use example scripts:
  - basic_search.py: Simple job search demonstration
  - json_output_example.py: JSON output formatting for LLMs
  - bd_intelligence_search.py: Business development market intelligence
  - federal_contractor_search.py: Federal contractor job searches

Enhanced:
- README.md: Added ChatGPT & LLM Integration section
- jobspy/__init__.py: Comprehensive docstrings for scrape_jobs()

The CLI supports multiple output formats (JSON, CSV, table, summary) and can accept parameters via command-line args or JSON stdin.