### PR TITLE
fix(linkedin): add fallback for date parsing on new job listings

### DIFF
--- a/jobspy/linkedin/__init__.py
+++ b/jobspy/linkedin/__init__.py
@@ -209,6 +209,10 @@ class LinkedIn(Scraper):
             if metadata_card
             else None
         )
+        if not datetime_tag and metadata_card:
+            datetime_tag = metadata_card.find(
+                "time", class_="job-search-card__listdate--new"
+            )
         date_posted = None
         if datetime_tag and "datetime" in datetime_tag.attrs:
             datetime_str = datetime_tag["datetime"]


### PR DESCRIPTION
                                                                                                  
  ## Summary                                                                       
                                                                                                                  
  **Problem:** LinkedIn uses two different CSS classes for job posting dates — `job-search-card__listdate` for
  older posts and `job-search-card__listdate--new` for recent posts (< 24h). The LinkedIn scraper only looks for
  `job-search-card__listdate`, so any job posted within the last 24 hours returns `date_posted` as `None`.

  **Solution:** Added a simple fallback in `_process_job` — if the primary `job-search-card__listdate` class isn't
   found on the `<time>` tag, we also check for `job-search-card__listdate--new`. The existing datetime parsing
  logic then handles both cases identically.