### PR TITLE
fix(glassdoor): fix CSRF token URL (404) and non-fatal GraphQL error handling

### DIFF
--- a/jobspy/glassdoor/__init__.py
+++ b/jobspy/glassdoor/__init__.py
@@ -121,7 +121,16 @@ class Glassdoor(Scraper):
                 raise GlassdoorException(exc_msg)
             res_json = response.json()[0]
             if "errors" in res_json:
-                raise ValueError("Error encountered in API response")
+                # Only treat errors on the jobListings field as fatal.
+                # Glassdoor commonly returns non-critical 503s on peripheral
+                # fields (e.g. jobsPageSeoData) while the job data is intact.
+                job_errors = [
+                    e for e in res_json["errors"]
+                    if "jobListings" in str(e.get("path", []))
+                    and "jobsPageSeoData" not in str(e.get("path", []))
+                ]
+                if job_errors:
+                    raise ValueError(f"Error encountered in jobListings API response: {job_errors}")
         except (
             requests.exceptions.ReadTimeout,
             GlassdoorException,
@@ -151,9 +160,10 @@ class Glassdoor(Scraper):
 
     def _get_csrf_token(self):
         """
-        Fetches csrf token needed for API by visiting a generic page
+        Fetches csrf token needed for API by visiting the homepage.
+        Previously used /Job/computer-science-jobs.htm which now returns 404.
         """
-        res = self.session.get(f"{self.base_url}/Job/computer-science-jobs.htm")
+        res = self.session.get(f"{self.base_url}/")
         pattern = r'"token":\s*"([^"]+)"'
         matches = re.findall(pattern, res.text)
         token = None


### PR DESCRIPTION
## Problem

Two bugs in `jobspy/glassdoor/__init__.py` cause Glassdoor to return 0 results regardless of location or search term.

### Bug 1 — CSRF token URL returns 404

`_get_csrf_token()` fetches `/Job/computer-science-jobs.htm` to extract the CSRF token. This URL now returns a 404 after Glassdoor's migration to Next.js. Without a valid token, the fallback token is used but the subsequent `_get_location()` call also fails with a 403 because the session is not properly initialized.

**Fix:** Fetch the homepage (`/`) instead, which reliably returns the token.

### Bug 2 — Non-fatal GraphQL errors abort all results

`_fetch_jobs_page()` raises `ValueError("Error encountered in API response")` if the GraphQL response contains **any** `errors` key. In practice, Glassdoor commonly returns non-critical 503 sub-errors on peripheral fields like `jobsPageSeoData` (SEO metadata) while the actual `jobListings` data is fully intact.

This causes the scraper to discard all 30 job results on every page.

**Fix:** Only treat errors on the `jobListings` path (excluding `jobsPageSeoData`) as fatal.

## Verification

Tested locally against `glassdoor.es` with `location="Spain"`, `search_term="engineer"`:
- **Before fix:** 0 results, `ERROR - Glassdoor: Error encountered in API response`
- **After fix:** 30 jobs returned, `totalJobsCount: 7576`

Related issues: #279, #270, #273