### PR TITLE
fix(glassdoor): URL-encode location param and tolerate non-fatal GraphQL errors

### DIFF
--- a/jobspy/glassdoor/__init__.py
+++ b/jobspy/glassdoor/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import re
 import json
 import requests
+from urllib.parse import quote
 from typing import Tuple
 from datetime import datetime, timedelta
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -120,7 +121,11 @@ class Glassdoor(Scraper):
                 exc_msg = f"bad response status code: {response.status_code}"
                 raise GlassdoorException(exc_msg)
             res_json = response.json()[0]
-            if "errors" in res_json:
+            if "errors" in res_json and (
+                "data" not in res_json
+                or not res_json["data"]
+                or "jobListings" not in res_json["data"]
+            ):
                 raise ValueError("Error encountered in API response")
         except (
             requests.exceptions.ReadTimeout,
@@ -258,7 +263,7 @@ class Glassdoor(Scraper):
     def _get_location(self, location: str, is_remote: bool) -> (int, str):
         if not location or is_remote:
             return "11047", "STATE"  # remote options
-        url = f"{self.base_url}/findPopularLocationAjax.htm?maxLocationsToReturn=10&term={location}"
+        url = f"{self.base_url}/findPopularLocationAjax.htm?maxLocationsToReturn=10&term={quote(location)}"
         res = self.session.get(url)
         if res.status_code != 200:
             if res.status_code == 429:


### PR DESCRIPTION
## Summary

Two bugs in the Glassdoor scraper that cause **all Glassdoor searches to silently return 0 results** when the location contains special characters (which is most locations):

- **URL encoding**: `_get_location()` interpolates the raw location string into a URL without encoding. Locations like `"Nashville, TN"` or `"New York, NY"` produce a malformed URL → Glassdoor returns HTTP 400 → `"location not parsed"` → empty results.
- **Non-fatal GraphQL errors**: Glassdoor's `/graph` endpoint sometimes returns partial errors (e.g. 503 on `jobsPageSeoData` SEO metadata) alongside valid job listing data. The current code treats any `"errors"` key as a total failure and discards the response, even when `data.jobListings` is fully populated.

## Changes

1. Added `from urllib.parse import quote` and wrapped the location term: `quote(location)`
2. Changed the error check to only bail when job listing data is actually missing from the response

## Testing

Before fix:
```
ERROR - Glassdoor response status code 400
ERROR - Glassdoor: location not parsed
Found 0 jobs from Glassdoor
```

After fix:
```
Location: id=1144541 type=CITY    ← Nashville resolves correctly
GraphQL Status: 200
Jobs found: 30                     ← Full results returned
```

Tested with: `"Nashville, TN"`, `"New York, NY"`, `"San Francisco, CA"` — all now return results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)