### PR TITLE
fix(linkedin): handle None job_level when LinkedIn omits "Seniority level"

### DIFF
--- a/jobspy/linkedin/__init__.py
+++ b/jobspy/linkedin/__init__.py
@@ -237,7 +237,7 @@ class LinkedIn(Scraper):
             job_url=f"{self.base_url}/jobs/view/{job_id}",
             compensation=compensation,
             job_type=job_details.get("job_type"),
-            job_level=job_details.get("job_level", "").lower(),
+            job_level=(job_details.get("job_level") or "").lower(),
             company_industry=job_details.get("company_industry"),
             description=job_details.get("description"),
             job_url_direct=job_details.get("job_url_direct"),


### PR DESCRIPTION
### Bug

[`linkedin/__init__.py:240`](https://github.com/speedyapply/JobSpy/blob/fda080a373e8226f3fd60635323f5da9af9892b1/jobspy/linkedin/__init__.py#L240) raises `AttributeError: 'NoneType' object has no attribute 'lower'` when `parse_job_level` ([`util.py:42`](https://github.com/speedyapply/JobSpy/blob/fda080a373e8226f3fd60635323f5da9af9892b1/jobspy/linkedin/util.py#L42)) returns `None` — which it correctly does (per its `-> str | None` signature) when the LinkedIn detail page lacks a "Seniority level" criterion. Common on non-US/UK postings (NL, DK, SE).

`dict.get(k, default)` only uses `default` when the **key** is missing, not when the value is `None`. So `.get("job_level", "")` returns `None`, and `None.lower()` raises.

The error aborts the entire `scrape_jobs` call, losing all results — including from other sites (Indeed, etc.) in the same invocation.

### Reproduction

```python
from bs4 import BeautifulSoup
from jobspy.linkedin.util import parse_job_level

# Detail page with Employment type + Industries but no "Seniority level"
soup = BeautifulSoup(
    '<h3 class="description__job-criteria-subheader">Employment type</h3>',
    "html.parser",
)
assert parse_job_level(soup) is None
{"job_level": parse_job_level(soup)}.get("job_level", "").lower()
# AttributeError: 'NoneType' object has no attribute 'lower'
```

### Impact

In a daily LinkedIn pipeline with `linkedin_fetch_description=True`, ~15–30% of queries abort this way. From one run:

```
WARNING jobspy: query 'head of innovation'/'Rotterdam'  failed: 'NoneType' object has no attribute 'lower'
WARNING jobspy: query 'circular economy'/'Netherlands'  failed: 'NoneType' object has no attribute 'lower'
WARNING jobspy: query 'head of innovation'/'Copenhagen' failed: 'NoneType' object has no attribute 'lower'
```

### Fix

`(job_details.get("job_level") or "").lower()` — handles both missing key and `None` value, preserves the existing `, ""` intent. Doesn't touch `parse_job_level`'s honest `str | None` signature; the call site is the bug.

Confirmed on `python-jobspy==1.1.82` (latest on PyPI) and `main` at [`fda080a`](https://github.com/speedyapply/JobSpy/commit/fda080a373e8226f3fd60635323f5da9af9892b1).

---

🤖 Written by [Claude Code](https://claude.com/claude-code).