### PR TITLE
Add regression test for Markdown list spacing

### DIFF
--- a/tests/test_markdown_converter.py
+++ b/tests/test_markdown_converter.py
@@ -1,0 +1,15 @@
+from jobspy.util import markdown_converter
+
+
+def test_markdown_converter_preserves_blank_line_before_list_after_heading():
+    html = (
+        "<strong>OUR HIRING PROCESS:<br/><br/></strong>"
+        "<ul><li>We will review your application against our job requirements.</li></ul>"
+    )
+
+    markdown = markdown_converter(html)
+
+    assert "**OUR HIRING PROCESS:**" in markdown
+    assert (
+        "\n\n* We will review your application against our job requirements." in markdown
+    )


### PR DESCRIPTION
## Summary
- add a synthetic regression test for LinkedIn HTML-to-Markdown conversion
- verify headings/strong blocks followed by `<ul>` render with a blank line before the first list item
- keep coverage offline with no network requests

## Why
LinkedIn descriptions can contain a heading or strong block followed by a `<ul>` list. Older converter output could produce Markdown like:

```md
**Heading:**
* item
```

Many Markdown renderers treat that as literal `*` text rather than a list. Current upstream dependency behavior produces:

```md
**Heading:**

* item
```

This test protects that behavior and helps prevent regressions in job description formatting for consumers using Markdown descriptions.

Upstream `speedyapply/JobSpy` already merged the `markdownify` bump in PR #290 (merge commit `84ed670df3b370bf3203aadbe3947bdaf4734439`), so this PR adds regression coverage to guard that behavior.

## Test details
- synthetic/offline fixture only
- no live scraping
- no network requests
