### PR TITLE
feat: add RemoteOK job source

### DIFF
--- a/jobspy/__init__.py
+++ b/jobspy/__init__.py
@@ -12,6 +12,7 @@ from jobspy.google import Google
 from jobspy.indeed import Indeed
 from jobspy.linkedin import LinkedIn
 from jobspy.naukri import Naukri
+from jobspy.remoteok import RemoteOK
 from jobspy.model import JobType, Location, JobResponse, Country
 from jobspy.model import SalarySource, ScraperInput, Site
 from jobspy.util import (
@@ -64,6 +65,7 @@ def scrape_jobs(
         Site.BAYT: BaytScraper,
         Site.NAUKRI: Naukri,
         Site.BDJOBS: BDJobs,  # Add BDJobs to the scraper mapping
+        Site.REMOTEOK: RemoteOK,
     }
     set_logger_level(verbose)
     job_type = get_enum_from_value(job_type) if job_type else None

--- a/jobspy/exception.py
+++ b/jobspy/exception.py
@@ -43,3 +43,7 @@ class NaukriException(Exception):
 class BDJobsException(Exception):
     def __init__(self, message=None):
         super().__init__(message or "An error occurred with BDJobs")
+
+class RemoteOKException(Exception):
+    def __init__(self, message=None):
+        super().__init__(message or "An error occurred with RemoteOK")

--- a/jobspy/model.py
+++ b/jobspy/model.py
@@ -294,6 +294,8 @@ class Site(Enum):
     NAUKRI = "naukri"
     BDJOBS = "bdjobs"  # Add this line
 
+    REMOTEOK = "remoteok"
+
 
 class SalarySource(Enum):
     DIRECT_DATA = "direct_data"

--- a/jobspy/remoteok/__init__.py
+++ b/jobspy/remoteok/__init__.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from jobspy.exception import RemoteOKException
+from jobspy.model import (
+    Compensation,
+    JobPost,
+    JobResponse,
+    Scraper,
+    ScraperInput,
+    Site,
+)
+from jobspy.remoteok.constant import headers, remoteok_api_url
+from jobspy.remoteok.util import (
+    matches_search_term,
+    parse_date,
+    parse_job_url,
+    parse_location,
+)
+from jobspy.util import create_logger, create_session
+
+log = create_logger("RemoteOK")
+
+
+class RemoteOK(Scraper):
+    api_url = remoteok_api_url
+
+    def __init__(
+        self,
+        proxies: list[str] | str | None = None,
+        ca_cert: str | None = None,
+        user_agent: str | None = None,
+    ):
+        """
+        Initializes RemoteOK scraper with the RemoteOK public API url.
+        """
+        super().__init__(Site.REMOTEOK, proxies=proxies, ca_cert=ca_cert)
+        self.session = create_session(
+            proxies=self.proxies,
+            ca_cert=ca_cert,
+            is_tls=False,
+            has_retry=True,
+        )
+        self.session.headers.update(headers)
+
+        if user_agent:
+            self.session.headers.update({"User-Agent": user_agent})
+
+    def scrape(self, scraper_input: ScraperInput) -> JobResponse:
+        """
+        Scrapes RemoteOK for jobs with scraper_input criteria.
+        :param scraper_input: Information about job search criteria.
+        :return: JobResponse containing a list of jobs.
+        """
+        job_list: list[JobPost] = []
+        seconds_old = scraper_input.hours_old * 3600 if scraper_input.hours_old else None
+        now_epoch = int(datetime.now(timezone.utc).timestamp())
+
+        try:
+            response = self.session.get(
+                self.api_url,
+                timeout=getattr(scraper_input, "request_timeout", 60),
+            )
+
+            if response.status_code != 200:
+                raise RemoteOKException(
+                    f"RemoteOK response status code {response.status_code}"
+                )
+
+            data = response.json()
+
+        except Exception as e:
+            log.error(f"RemoteOK: {str(e)}")
+            return JobResponse(jobs=[])
+
+        for item in data[1:]:
+            try:
+                if not matches_search_term(item, scraper_input.search_term):
+                    continue
+
+                if seconds_old:
+                    epoch = item.get("epoch")
+                    if epoch and now_epoch - int(epoch) > seconds_old:
+                        continue
+
+                job_post = self._process_job(item)
+
+                if job_post:
+                    job_list.append(job_post)
+
+                if len(job_list) >= scraper_input.results_wanted:
+                    break
+
+            except Exception as e:
+                log.error(f"Error processing RemoteOK job: {str(e)}")
+
+        return JobResponse(jobs=job_list)
+
+    def _process_job(self, job: dict) -> JobPost | None:
+        """
+        Processes a RemoteOK job item into a JobPost object.
+        :param job: RemoteOK job dictionary.
+        :return: JobPost object.
+        """
+        salary_min = job.get("salary_min")
+        salary_max = job.get("salary_max")
+        compensation = None
+
+        if salary_min and salary_max:
+            compensation = Compensation(
+                min_amount=float(salary_min),
+                max_amount=float(salary_max),
+                currency="USD",
+            )
+
+        return JobPost(
+            id=f"remoteok-{job.get('id')}",
+            title=job.get("position") or "N/A",
+            company_name=job.get("company"),
+            location=parse_location(job.get("location")),
+            date_posted=parse_date(job.get("date")),
+            job_url=parse_job_url(job.get("url") or job.get("apply_url")),
+            job_url_direct=parse_job_url(job.get("apply_url")),
+            description=job.get("description"),
+            company_logo=job.get("company_logo") or job.get("logo"),
+            compensation=compensation,
+            is_remote=True,
+            skills=job.get("tags") or None,
+        )

--- a/jobspy/remoteok/constant.py
+++ b/jobspy/remoteok/constant.py
@@ -1,0 +1,6 @@
+headers = {
+    "User-Agent": "Mozilla/5.0",
+    "Accept": "application/json",
+}
+
+remoteok_api_url = "https://remoteok.com/api"

--- a/jobspy/remoteok/util.py
+++ b/jobspy/remoteok/util.py
@@ -1,0 +1,42 @@
+from datetime import datetime
+from urllib.parse import urljoin
+
+from jobspy.model import Location
+
+
+def parse_date(date_str):
+    if not date_str:
+        return None
+    try:
+        return datetime.fromisoformat(date_str.replace("Z", "+00:00")).date()
+    except Exception:
+        return None
+
+
+def parse_location(location_text):
+    if not location_text:
+        return None
+    return Location(city=location_text)
+
+
+def parse_job_url(url):
+    if not url:
+        return None
+    return urljoin("https://remoteok.com", url)
+
+
+def matches_search_term(job, search_term):
+    if not search_term:
+        return True
+
+    tags = job.get("tags") or []
+    text = " ".join(
+        [
+            job.get("position") or "",
+            job.get("company") or "",
+            job.get("description") or "",
+            " ".join(tags),
+        ]
+    ).lower()
+
+    return search_term.lower() in text


### PR DESCRIPTION
Adds support for RemoteOK as a new job source.

I noticed JobSpy already supports several job boards, so I thought RemoteOK would be a useful addition for people looking specifically for remote opportunities.

What this PR adds:

* RemoteOK scraper using the public RemoteOK API
* New `remoteok` site enum
* Registration in the scraper mapping
* Mapping of RemoteOK jobs into the existing JobPost schema
* Basic support for `search_term`, `hours_old`, and `results_wanted`
* Utility functions for parsing dates, locations, and URLs

Tested locally with:

* scrape_jobs(site_name=["remoteok"], results_wanted=5)
* scrape_jobs(site_name=["remoteok"], search_term="engineer", results_wanted=5)
* python -m compileall jobspy

This is my first contribution to JobSpy, so I'm happy to make any changes if there's a different preferred structure or approach for new job sources. Thanks for taking a look!
