### PR TITLE
Add LinkedIn applicants count to job posts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,15 @@
 *.pyc
 .env
 dist
+
+# Personal job scraper outputs
+/jobs_master.csv
+/yoe_checkpoint.csv
+/yoe_llm_cache.sqlite3
+/notified_keys.txt
+/reports/
+/local_scripts/linkedin_applicant_notifier/jobs_master.csv
+/local_scripts/linkedin_applicant_notifier/yoe_checkpoint.csv
+/local_scripts/linkedin_applicant_notifier/yoe_llm_cache.sqlite3
+/local_scripts/linkedin_applicant_notifier/notified_keys.txt
+/local_scripts/linkedin_applicant_notifier/reports/

--- a/jobspy/linkedin/__init__.py
+++ b/jobspy/linkedin/__init__.py
@@ -238,6 +238,7 @@ class LinkedIn(Scraper):
             compensation=compensation,
             job_type=job_details.get("job_type"),
             job_level=job_details.get("job_level", "").lower(),
+            applicants=job_details.get("applicants"),
             company_industry=job_details.get("company_industry"),
             description=job_details.get("description"),
             job_url_direct=job_details.get("job_url_direct"),
@@ -291,6 +292,7 @@ class LinkedIn(Scraper):
             if (logo_image := soup.find("img", {"class": "artdeco-entity-image"}))
             else None
         )
+        applicants = self._parse_applicants(soup)
         return {
             "description": description,
             "job_level": parse_job_level(soup),
@@ -299,7 +301,23 @@ class LinkedIn(Scraper):
             "job_url_direct": self._parse_job_url_direct(soup),
             "company_logo": company_logo,
             "job_function": job_function,
+            "applicants": applicants,
         }
+
+    def _parse_applicants(self, soup: BeautifulSoup) -> str | None:
+        applicants_caption = soup.find(
+            class_=lambda x: x and "num-applicants__caption" in x
+        )
+        if applicants_caption:
+            return applicants_caption.get_text(separator=" ", strip=True)
+
+        applicants_figure = soup.find(
+            "figure", class_=lambda x: x and "num-applicants__figure" in x
+        )
+        if applicants_figure:
+            return applicants_figure.get_text(separator=" ", strip=True)
+
+        return None
 
     def _get_location(self, metadata_card: Optional[Tag]) -> Location:
         """

--- a/jobspy/model.py
+++ b/jobspy/model.py
@@ -257,6 +257,7 @@ class JobPost(BaseModel):
 
     # LinkedIn specific
     job_level: str | None = None
+    applicants: str | None = None
 
     # LinkedIn and Indeed specific
     company_industry: str | None = None

--- a/jobspy/util.py
+++ b/jobspy/util.py
@@ -341,6 +341,7 @@ desired_order = [
     "currency",
     "is_remote",
     "job_level",
+    "applicants",
     "job_function",
     "listing_type",
     "emails",

--- a/local_scripts/linkedin_applicant_notifier/enrich_yoe.py
+++ b/local_scripts/linkedin_applicant_notifier/enrich_yoe.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import pandas as pd
+from tqdm import tqdm
+
+from yoe_llm_client import extract_yoe_requirement
+
+
+def enrich_jobs_with_yoe(
+    df: pd.DataFrame,
+    description_col: str,
+    checkpoint_path: str = "yoe_checkpoint.csv",
+    checkpoint_every: int = 10,
+) -> pd.DataFrame:
+    if df is None or df.empty:
+        return df
+
+    work = df.copy()
+    for column in ["company", "title", description_col]:
+        if column not in work.columns:
+            work[column] = ""
+
+    for column in ["yoe_required", "extracted_time"]:
+        if column not in work.columns:
+            work[column] = ""
+
+    for index, row in tqdm(work.iterrows(), total=len(work), desc="YOE LLM"):
+        info = extract_yoe_requirement(
+            company=str(row.get("company", "") or ""),
+            title=str(row.get("title", "") or ""),
+            job_description=str(row.get(description_col, "") or ""),
+        )
+        work.at[index, "yoe_required"] = info.get("yoe_required", 0)
+        work.at[index, "extracted_time"] = info.get("extracted_time", "")
+
+        if checkpoint_every and (int(index) + 1) % checkpoint_every == 0:
+            work.to_csv(checkpoint_path, index=False)
+
+    work.to_csv(checkpoint_path, index=False)
+    return work

--- a/local_scripts/linkedin_applicant_notifier/enrich_yoe.py
+++ b/local_scripts/linkedin_applicant_notifier/enrich_yoe.py
@@ -20,7 +20,7 @@ def enrich_jobs_with_yoe(
         if column not in work.columns:
             work[column] = ""
 
-    for column in ["yoe_required", "extracted_time"]:
+    for column in ["yoe_required", "skill_fit", "extracted_time"]:
         if column not in work.columns:
             work[column] = ""
 
@@ -31,6 +31,7 @@ def enrich_jobs_with_yoe(
             job_description=str(row.get(description_col, "") or ""),
         )
         work.at[index, "yoe_required"] = info.get("yoe_required", 0)
+        work.at[index, "skill_fit"] = info.get("skill_fit", False)
         work.at[index, "extracted_time"] = info.get("extracted_time", "")
 
         if checkpoint_every and (int(index) + 1) % checkpoint_every == 0:

--- a/local_scripts/linkedin_applicant_notifier/excluded_companies.txt
+++ b/local_scripts/linkedin_applicant_notifier/excluded_companies.txt
@@ -57,3 +57,8 @@ Goliath Partners
 General Dynamics Mission Systems
 TalentAlly
 PNC
+Anrok
+Scale.jobs
+IBM
+Infosys
+Visa

--- a/local_scripts/linkedin_applicant_notifier/excluded_companies.txt
+++ b/local_scripts/linkedin_applicant_notifier/excluded_companies.txt
@@ -52,3 +52,8 @@ Harvey Nash
 Akkodis
 TECHEAD
 Beacon Hill
+Booz Allen Hamilton
+Goliath Partners
+General Dynamics Mission Systems
+TalentAlly
+PNC

--- a/local_scripts/linkedin_applicant_notifier/excluded_companies.txt
+++ b/local_scripts/linkedin_applicant_notifier/excluded_companies.txt
@@ -42,3 +42,6 @@ Accenture Federal Services
 Underdog.io -Apply to top tech jobs in 60 seconds. A place where companies apply to you
 Lumenalta
 Anduril Industries
+BeaconFire Inc.
+Confidential Jobs
+UMATR

--- a/local_scripts/linkedin_applicant_notifier/excluded_companies.txt
+++ b/local_scripts/linkedin_applicant_notifier/excluded_companies.txt
@@ -15,3 +15,30 @@ Jobs via eFinancialCareers
 CVS Health
 Lockheed Martin
 HireBuddy
+Great Value Hiring
+BulkSource, Inc.
+ChatGPT Jobs
+FetchJobs.co
+Cognizant
+Deloitte
+Experis
+hackajob
+Haystack
+TikTok USDS Joint Venture
+Acceler8 Talent
+Stealth Startup
+Jobot
+General Dynamics Information Technology
+Hyra
+Capgemini
+Jobgether
+Crossing Hurdles
+micro1
+Hired
+Hire Feed
+Accenture
+Wells Fargo
+Accenture Federal Services
+Underdog.io -Apply to top tech jobs in 60 seconds. A place where companies apply to you
+Lumenalta
+Anduril Industries

--- a/local_scripts/linkedin_applicant_notifier/excluded_companies.txt
+++ b/local_scripts/linkedin_applicant_notifier/excluded_companies.txt
@@ -13,3 +13,5 @@ RemoteHunter
 Jobright.ai
 Jobs via eFinancialCareers
 CVS Health
+Lockheed Martin
+HireBuddy

--- a/local_scripts/linkedin_applicant_notifier/excluded_companies.txt
+++ b/local_scripts/linkedin_applicant_notifier/excluded_companies.txt
@@ -9,3 +9,7 @@ Jobs via Dice
 Brain Corp
 Sundayy
 Citi
+RemoteHunter
+Jobright.ai
+Jobs via eFinancialCareers
+CVS Health

--- a/local_scripts/linkedin_applicant_notifier/excluded_companies.txt
+++ b/local_scripts/linkedin_applicant_notifier/excluded_companies.txt
@@ -62,3 +62,5 @@ Scale.jobs
 IBM
 Infosys
 Visa
+Bain & Company
+PwC

--- a/local_scripts/linkedin_applicant_notifier/excluded_companies.txt
+++ b/local_scripts/linkedin_applicant_notifier/excluded_companies.txt
@@ -1,0 +1,9 @@
+# One exact company name per line.
+# Lines starting with # are ignored.
+Revature
+DataAnnotation
+Jack & Jill
+Turing
+Deloitte
+Jobs via Dice
+Brain Corp

--- a/local_scripts/linkedin_applicant_notifier/excluded_companies.txt
+++ b/local_scripts/linkedin_applicant_notifier/excluded_companies.txt
@@ -7,3 +7,5 @@ Turing
 Deloitte
 Jobs via Dice
 Brain Corp
+Sundayy
+Citi

--- a/local_scripts/linkedin_applicant_notifier/excluded_companies.txt
+++ b/local_scripts/linkedin_applicant_notifier/excluded_companies.txt
@@ -45,3 +45,10 @@ Anduril Industries
 BeaconFire Inc.
 Confidential Jobs
 UMATR
+Insight Global
+People In AI
+Radiant Digital
+Harvey Nash
+Akkodis
+TECHEAD
+Beacon Hill

--- a/local_scripts/linkedin_applicant_notifier/excluded_companies.txt
+++ b/local_scripts/linkedin_applicant_notifier/excluded_companies.txt
@@ -64,3 +64,8 @@ Infosys
 Visa
 Bain & Company
 PwC
+Bosch USA
+Tata Consultancy Services
+Northrop Grumman
+MicroAI
+Red Hat

--- a/local_scripts/linkedin_applicant_notifier/excluded_company_keywords.txt
+++ b/local_scripts/linkedin_applicant_notifier/excluded_company_keywords.txt
@@ -1,0 +1,5 @@
+# One company-name keyword or phrase per line.
+# Lines starting with # are ignored.
+consulting
+staffing
+recruiting

--- a/local_scripts/linkedin_applicant_notifier/excluded_company_keywords.txt
+++ b/local_scripts/linkedin_applicant_notifier/excluded_company_keywords.txt
@@ -3,4 +3,4 @@
 consulting
 staffing
 recruiting
-Jobright
+Recruitment

--- a/local_scripts/linkedin_applicant_notifier/excluded_company_keywords.txt
+++ b/local_scripts/linkedin_applicant_notifier/excluded_company_keywords.txt
@@ -3,3 +3,4 @@
 consulting
 staffing
 recruiting
+Jobright

--- a/local_scripts/linkedin_applicant_notifier/run_linkedin_applicant_notifier.py
+++ b/local_scripts/linkedin_applicant_notifier/run_linkedin_applicant_notifier.py
@@ -403,6 +403,7 @@ def send_email(subject: str, body_text: str, body_html: str | None = None) -> bo
     user = os.getenv("SMTP_USER", "").strip()
     password = os.getenv("SMTP_PASS", "").strip()
     to_addr = os.getenv("EMAIL_TO", "").strip()
+    bcc_addrs = split_env_list(os.getenv("EMAIL_BCC", ""))
     from_addr = os.getenv("EMAIL_FROM", "").strip() or user
 
     if not (host and user and password and to_addr):
@@ -413,6 +414,8 @@ def send_email(subject: str, body_text: str, body_html: str | None = None) -> bo
     msg["Subject"] = subject
     msg["From"] = from_addr
     msg["To"] = to_addr
+    if bcc_addrs:
+        msg["Bcc"] = ", ".join(bcc_addrs)
     msg.set_content(body_text)
     if body_html:
         msg.add_alternative(body_html, subtype="html")

--- a/local_scripts/linkedin_applicant_notifier/run_linkedin_applicant_notifier.py
+++ b/local_scripts/linkedin_applicant_notifier/run_linkedin_applicant_notifier.py
@@ -172,11 +172,8 @@ def prepare_jobs_for_dedupe(df: pd.DataFrame) -> pd.DataFrame:
 def internal_dedupe_new_batch(df: pd.DataFrame) -> pd.DataFrame:
     work = df.copy()
     if "site" in work.columns and "id" in work.columns:
-        work = work.drop_duplicates(subset=["site", "id"], keep="first")
-    return work.drop_duplicates(
-        subset=["title_norm", "company_norm", "location_norm"],
-        keep="first",
-    )
+        return work.drop_duplicates(subset=["site", "id"], keep="first")
+    return work
 
 
 def filter_new_vs_master(
@@ -193,26 +190,11 @@ def filter_new_vs_master(
             zip(master_work["site"].astype(str), master_work["id"].astype(str))
         )
 
-    title_company_location_keys = set(
-        zip(
-            master_work["title_norm"],
-            master_work["company_norm"],
-            master_work["location_norm"],
-        )
-    )
-
     keep_rows = []
     for _, row in new_jobs.iterrows():
         site_id_key = (str(row.get("site", "")), str(row.get("id", "")))
-        title_company_location_key = (
-            row.get("title_norm", ""),
-            row.get("company_norm", ""),
-            row.get("location_norm", ""),
-        )
 
         if site_id_key in site_id_keys:
-            continue
-        if title_company_location_key in title_company_location_keys:
             continue
         keep_rows.append(row)
 

--- a/local_scripts/linkedin_applicant_notifier/run_linkedin_applicant_notifier.py
+++ b/local_scripts/linkedin_applicant_notifier/run_linkedin_applicant_notifier.py
@@ -54,6 +54,7 @@ FINAL_COLUMNS = [
     "date_posted",
     "applicants",
     "yoe_required",
+    "skill_fit",
     "extracted_time",
 ]
 
@@ -309,12 +310,30 @@ def filter_by_max_yoe(df: pd.DataFrame) -> pd.DataFrame:
     return filtered
 
 
+def filter_by_skill_fit(df: pd.DataFrame) -> pd.DataFrame:
+    if df is None or df.empty:
+        return df
+
+    work = df.copy()
+    if "skill_fit" not in work.columns:
+        work["skill_fit"] = False
+
+    skill_fit = work["skill_fit"].map(
+        lambda value: value
+        if isinstance(value, bool)
+        else str(value).strip().lower() in {"true", "1", "yes", "y"}
+    )
+    filtered = work.loc[skill_fit].copy()
+    print(f"Skill-fit filter: kept {len(filtered)} of {len(work)} jobs")
+    return filtered
+
+
 def build_markdown_report(df: pd.DataFrame) -> str:
     now = datetime.now(UTC).strftime("%Y-%m-%d %H:%M UTC")
     lines = [
         (
             f"# LinkedIn jobs under {APPLICANT_LIMIT} applicants and "
-            f"YOE <= {MAX_YOE_REQUIRED} ({now})"
+            f"YOE <= {MAX_YOE_REQUIRED}, skill fit only ({now})"
         ),
         "",
     ]
@@ -489,27 +508,30 @@ def main() -> None:
     )
 
     jobs_to_notify = filter_by_max_yoe(enriched_jobs)
+    jobs_to_notify = filter_by_skill_fit(jobs_to_notify)
     jobs_to_notify = keep_final_columns(jobs_to_notify)
     write_markdown_report(jobs_to_notify)
 
     if jobs_to_notify.empty:
-        print("No new jobs under applicant and YOE limits to notify.")
+        print("No new jobs under applicant, YOE, and skill-fit limits to notify.")
+        save_master(master, keep_final_columns(enriched_jobs))
+        print(f"Wrote report: {REPORT_MD_PATH}")
         return
 
     email_sent = send_email(
         subject=(
             f"[LinkedIn jobs under {APPLICANT_LIMIT} applicants, "
-            f"YOE <= {MAX_YOE_REQUIRED}] "
+            f"YOE <= {MAX_YOE_REQUIRED}, skill fit] "
             f"{len(jobs_to_notify)} new jobs"
         ),
         body_text=(
             f"LinkedIn jobs under {APPLICANT_LIMIT} applicants "
-            f"and YOE <= {MAX_YOE_REQUIRED}:\n\n"
+            f"and YOE <= {MAX_YOE_REQUIRED}, filtered for skill fit:\n\n"
             + df_to_plain_table(jobs_to_notify)
         ),
         body_html=(
             f"<h3>LinkedIn jobs under {APPLICANT_LIMIT} applicants "
-            f"and YOE <= {MAX_YOE_REQUIRED}</h3>"
+            f"and YOE <= {MAX_YOE_REQUIRED}, filtered for skill fit</h3>"
             + df_to_html_table(jobs_to_notify)
         ),
     )

--- a/local_scripts/linkedin_applicant_notifier/run_linkedin_applicant_notifier.py
+++ b/local_scripts/linkedin_applicant_notifier/run_linkedin_applicant_notifier.py
@@ -37,11 +37,11 @@ APPLICANT_LIMIT = int(os.getenv("JOB_APPLICANT_LIMIT", "200"))
 MAX_YOE_REQUIRED = int(os.getenv("JOB_MAX_YOE_REQUIRED", "0"))
 YOE_CHECKPOINT_PATH = os.getenv("YOE_CHECKPOINT_PATH", "yoe_checkpoint.csv")
 EXCLUDED_COMPANIES_RAW = os.getenv("JOB_EXCLUDED_COMPANIES", "")
-EXCLUDED_COMPANIES_FILE = os.getenv(
-    "JOB_EXCLUDED_COMPANIES_FILE", "excluded_companies.txt"
+EXCLUDED_COMPANIES_FILE = (
+    os.getenv("JOB_EXCLUDED_COMPANIES_FILE") or "excluded_companies.txt"
 )
 EXCLUDED_COMPANY_KEYWORDS_RAW = os.getenv("JOB_EXCLUDED_COMPANY_KEYWORDS", "")
-EXCLUDED_COMPANY_KEYWORDS_FILE = os.getenv("JOB_EXCLUDED_COMPANY_KEYWORDS_FILE", "")
+EXCLUDED_COMPANY_KEYWORDS_FILE = os.getenv("JOB_EXCLUDED_COMPANY_KEYWORDS_FILE") or ""
 
 FINAL_COLUMNS = [
     "id",
@@ -228,6 +228,12 @@ def filter_excluded_companies(df: pd.DataFrame) -> pd.DataFrame:
     if not excluded_exact and not excluded_keywords:
         print("Company filter: no excluded companies configured")
         return df
+
+    print(
+        "Company filter: loaded "
+        f"{len(excluded_exact)} exact exclusions and "
+        f"{len(excluded_keywords)} keyword exclusions"
+    )
 
     work = df.copy()
     if "company" not in work.columns:

--- a/local_scripts/linkedin_applicant_notifier/run_linkedin_applicant_notifier.py
+++ b/local_scripts/linkedin_applicant_notifier/run_linkedin_applicant_notifier.py
@@ -1,0 +1,520 @@
+from __future__ import annotations
+
+import csv
+import json
+import os
+import re
+import smtplib
+import sys
+import unicodedata
+from datetime import UTC, datetime
+from email.message import EmailMessage
+from pathlib import Path
+
+import pandas as pd
+from dotenv import load_dotenv
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from jobspy import scrape_jobs
+
+load_dotenv(SCRIPT_DIR / ".env")
+load_dotenv(SCRIPT_DIR / ".env.local", override=True)
+
+MASTER_CSV_PATH = Path("jobs_master.csv")
+REPORT_MD_PATH = Path("reports/latest.md")
+
+SEARCH_TERM = os.getenv("JOB_SEARCH_TERM", "Software Engineer")
+LOCATION = os.getenv("JOB_LOCATION", "United States")
+RESULTS_WANTED = int(os.getenv("JOB_RESULTS_WANTED", "700"))
+HOURS_OLD = int(os.getenv("JOB_HOURS_OLD", "1"))
+APPLICANT_LIMIT = int(os.getenv("JOB_APPLICANT_LIMIT", "200"))
+MAX_YOE_REQUIRED = int(os.getenv("JOB_MAX_YOE_REQUIRED", "0"))
+YOE_CHECKPOINT_PATH = os.getenv("YOE_CHECKPOINT_PATH", "yoe_checkpoint.csv")
+EXCLUDED_COMPANIES_RAW = os.getenv("JOB_EXCLUDED_COMPANIES", "")
+EXCLUDED_COMPANIES_FILE = os.getenv(
+    "JOB_EXCLUDED_COMPANIES_FILE", "excluded_companies.txt"
+)
+EXCLUDED_COMPANY_KEYWORDS_RAW = os.getenv("JOB_EXCLUDED_COMPANY_KEYWORDS", "")
+EXCLUDED_COMPANY_KEYWORDS_FILE = os.getenv("JOB_EXCLUDED_COMPANY_KEYWORDS_FILE", "")
+
+FINAL_COLUMNS = [
+    "id",
+    "site",
+    "job_url",
+    "job_url_direct",
+    "title",
+    "company",
+    "location",
+    "date_posted",
+    "applicants",
+    "yoe_required",
+    "extracted_time",
+]
+
+_MOJI_REPLACEMENTS = {
+    "Ãƒâ€”": "Ã—",
+    "Ã¢â‚¬â€": "â€”",
+    "Ã¢â‚¬â€œ": "â€“",
+    "Ã¢â‚¬Ëœ": "â€˜",
+    "Ã¢â‚¬â„¢": "â€™",
+    "Ã¢â‚¬Å“": "â€œ",
+    "Ã¢â‚¬ï¿½": "â€",
+    "Ã‚": "",
+}
+
+
+def clean_text(value: object) -> str:
+    if value is None:
+        return ""
+    text = str(value)
+    for bad, good in _MOJI_REPLACEMENTS.items():
+        text = text.replace(bad, good)
+    text = unicodedata.normalize("NFKC", text)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def norm_key(value: object) -> str:
+    text = clean_text(value).lower()
+    text = re.sub(r"[^\w\s]", " ", text)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def split_env_list(value: str) -> list[str]:
+    value = (value or "").strip()
+    if not value:
+        return []
+
+    if value.startswith("["):
+        try:
+            parsed = json.loads(value)
+            if isinstance(parsed, list):
+                return [str(item).strip() for item in parsed if str(item).strip()]
+        except json.JSONDecodeError:
+            pass
+
+    return [item.strip() for item in re.split(r"[,;\n]+", value or "") if item.strip()]
+
+
+def load_list_from_file(file_value: str) -> set[str]:
+    if not file_value:
+        return set()
+
+    file_path = Path(file_value)
+    if not file_path.is_absolute():
+        file_path = SCRIPT_DIR / file_path
+
+    values = set()
+    if file_path.exists():
+        for line in file_path.read_text(encoding="utf-8").splitlines():
+            value = line.strip()
+            if value and not value.startswith("#"):
+                values.add(value)
+
+    return values
+
+
+def load_excluded_companies() -> set[str]:
+    companies = set(split_env_list(EXCLUDED_COMPANIES_RAW))
+    companies.update(load_list_from_file(EXCLUDED_COMPANIES_FILE))
+    return {norm_key(company) for company in companies}
+
+
+def load_excluded_company_keywords() -> list[str]:
+    keywords = set(split_env_list(EXCLUDED_COMPANY_KEYWORDS_RAW))
+    keywords.update(load_list_from_file(EXCLUDED_COMPANY_KEYWORDS_FILE))
+    return sorted(norm_key(keyword) for keyword in keywords if norm_key(keyword))
+
+
+def keep_final_columns(df: pd.DataFrame) -> pd.DataFrame:
+    out = df.copy()
+    for column in FINAL_COLUMNS:
+        if column not in out.columns:
+            out[column] = ""
+    return out[FINAL_COLUMNS].copy()
+
+
+def find_description_column(df: pd.DataFrame) -> str:
+    for column in ["description", "job_description", "job_desc"]:
+        if column in df.columns:
+            return column
+    return "description"
+
+
+def load_master() -> pd.DataFrame | None:
+    if not MASTER_CSV_PATH.exists():
+        return None
+    try:
+        return pd.read_csv(MASTER_CSV_PATH)
+    except Exception:
+        return None
+
+
+def prepare_jobs_for_dedupe(df: pd.DataFrame) -> pd.DataFrame:
+    work = df.copy()
+    for column in ["title", "company", "location"]:
+        if column not in work.columns:
+            work[column] = ""
+        work[column] = work[column].astype(str).fillna("").map(clean_text)
+
+    work["title_norm"] = work["title"].map(norm_key)
+    work["company_norm"] = work["company"].map(norm_key)
+    work["location_norm"] = work["location"].map(norm_key)
+    return work
+
+
+def internal_dedupe_new_batch(df: pd.DataFrame) -> pd.DataFrame:
+    work = df.copy()
+    if "site" in work.columns and "id" in work.columns:
+        work = work.drop_duplicates(subset=["site", "id"], keep="first")
+    return work.drop_duplicates(
+        subset=["title_norm", "company_norm", "location_norm"],
+        keep="first",
+    )
+
+
+def filter_new_vs_master(
+    master: pd.DataFrame | None, new_jobs: pd.DataFrame
+) -> pd.DataFrame:
+    if master is None or master.empty:
+        return new_jobs
+
+    master_work = prepare_jobs_for_dedupe(master)
+
+    site_id_keys = set()
+    if "site" in master_work.columns and "id" in master_work.columns:
+        site_id_keys = set(
+            zip(master_work["site"].astype(str), master_work["id"].astype(str))
+        )
+
+    title_company_location_keys = set(
+        zip(
+            master_work["title_norm"],
+            master_work["company_norm"],
+            master_work["location_norm"],
+        )
+    )
+
+    keep_rows = []
+    for _, row in new_jobs.iterrows():
+        site_id_key = (str(row.get("site", "")), str(row.get("id", "")))
+        title_company_location_key = (
+            row.get("title_norm", ""),
+            row.get("company_norm", ""),
+            row.get("location_norm", ""),
+        )
+
+        if site_id_key in site_id_keys:
+            continue
+        if title_company_location_key in title_company_location_keys:
+            continue
+        keep_rows.append(row)
+
+    return pd.DataFrame(keep_rows) if keep_rows else new_jobs.iloc[0:0].copy()
+
+
+def filter_excluded_companies(df: pd.DataFrame) -> pd.DataFrame:
+    if df is None or df.empty:
+        return df
+
+    excluded_exact = load_excluded_companies()
+    excluded_keywords = load_excluded_company_keywords()
+
+    if not excluded_exact and not excluded_keywords:
+        print("Company filter: no excluded companies configured")
+        return df
+
+    work = df.copy()
+    if "company" not in work.columns:
+        work["company"] = ""
+
+    company_norm = work["company"].map(norm_key)
+    excluded_mask = company_norm.map(
+        lambda company: company in excluded_exact
+        or any(keyword in company for keyword in excluded_keywords)
+    )
+    filtered = work.loc[~excluded_mask].copy()
+
+    print(
+        f"Company filter: removed {int(excluded_mask.sum())} of {len(work)} jobs "
+        "from excluded companies"
+    )
+    return filtered
+
+
+def parse_applicant_count(applicants: object) -> int | None:
+    text = clean_text(applicants).lower()
+    if not text:
+        return None
+
+    if "over 200" in text or "more than 200" in text:
+        return APPLICANT_LIMIT + 1
+
+    first_match = re.search(r"first\s+(\d+)", text)
+    if first_match:
+        return int(first_match.group(1))
+
+    applicants_match = re.search(r"(\d[\d,]*)\s+applicants?", text)
+    if applicants_match:
+        return int(applicants_match.group(1).replace(",", ""))
+
+    return None
+
+
+def filter_under_applicant_limit(df: pd.DataFrame) -> pd.DataFrame:
+    if df is None or df.empty:
+        return df
+
+    work = df.copy()
+    if "applicants" not in work.columns:
+        work["applicants"] = ""
+
+    applicant_counts = work["applicants"].map(parse_applicant_count)
+    filtered = work.loc[
+        applicant_counts.notna() & (applicant_counts < APPLICANT_LIMIT)
+    ].copy()
+
+    print(
+        f"Applicant filter: kept {len(filtered)} of {len(work)} jobs "
+        f"with fewer than {APPLICANT_LIMIT} applicants"
+    )
+    return filtered
+
+
+def filter_by_max_yoe(df: pd.DataFrame) -> pd.DataFrame:
+    if df is None or df.empty:
+        return df
+
+    work = df.copy()
+    if "yoe_required" not in work.columns:
+        work["yoe_required"] = 0
+
+    yoe = pd.to_numeric(work["yoe_required"], errors="coerce").fillna(0)
+    filtered = work.loc[yoe <= MAX_YOE_REQUIRED].copy()
+    print(
+        f"YOE filter: kept {len(filtered)} of {len(work)} jobs "
+        f"with YOE <= {MAX_YOE_REQUIRED}"
+    )
+    return filtered
+
+
+def build_markdown_report(df: pd.DataFrame) -> str:
+    now = datetime.now(UTC).strftime("%Y-%m-%d %H:%M UTC")
+    lines = [
+        (
+            f"# LinkedIn jobs under {APPLICANT_LIMIT} applicants and "
+            f"YOE <= {MAX_YOE_REQUIRED} ({now})"
+        ),
+        "",
+    ]
+
+    if df is None or df.empty:
+        lines.append("_No new jobs matched this run._")
+        return "\n".join(lines)
+
+    df = sort_for_notification(df)
+
+    lines.append("| Title | Company | Job Link | Applicants | YOE Required |")
+    lines.append("|---|---|---|---|---:|")
+
+    for _, row in df.iterrows():
+        title = str(row.get("title", "")).replace("|", "\\|")
+        company = str(row.get("company", "")).replace("|", "\\|")
+        applicants = str(row.get("applicants", "") or "").replace("|", "\\|")
+        yoe_required = str(row.get("yoe_required", "") or "")
+        job_url = str(row.get("job_url", "") or "").strip()
+        link = f"[link]({job_url})" if job_url else ""
+        lines.append(f"| {title} | {company} | {link} | {applicants} | {yoe_required} |")
+
+    return "\n".join(lines)
+
+
+def write_markdown_report(df: pd.DataFrame) -> None:
+    REPORT_MD_PATH.parent.mkdir(parents=True, exist_ok=True)
+    REPORT_MD_PATH.write_text(build_markdown_report(df).strip() + "\n", encoding="utf-8")
+
+
+def df_to_plain_table(df: pd.DataFrame) -> str:
+    columns = ["title", "company", "job_url", "applicants", "yoe_required"]
+    table = sort_for_notification(df)
+    for column in columns:
+        if column not in table.columns:
+            table[column] = ""
+    table = table[columns]
+    table.columns = ["Title", "Company", "Job Link", "Applicants", "YOE Required"]
+    return table.to_string(index=False)
+
+
+def df_to_html_table(df: pd.DataFrame) -> str:
+    rows = []
+    df = sort_for_notification(df)
+    for _, row in df.iterrows():
+        job_url = str(row.get("job_url", "") or "").strip()
+        link_html = f'<a href="{job_url}">link</a>' if job_url else ""
+        rows.append(
+            "<tr>"
+            f"<td>{row.get('title', '')}</td>"
+            f"<td>{row.get('company', '')}</td>"
+            f"<td>{link_html}</td>"
+            f"<td>{row.get('applicants', '')}</td>"
+            f"<td>{row.get('yoe_required', '')}</td>"
+            "</tr>"
+        )
+
+    return (
+        "<table border='1' cellpadding='6' cellspacing='0'>"
+        "<thead><tr>"
+        "<th>Title</th><th>Company</th><th>Job Link</th>"
+        "<th>Applicants</th><th>YOE Required</th>"
+        "</tr></thead><tbody>"
+        + "".join(rows)
+        + "</tbody></table>"
+    )
+
+
+def sort_for_notification(df: pd.DataFrame) -> pd.DataFrame:
+    if df is None or df.empty:
+        return df
+
+    sorted_df = df.copy()
+    sorted_df["__yoe_sort"] = pd.to_numeric(
+        sorted_df.get("yoe_required", 0), errors="coerce"
+    ).fillna(0)
+    return sorted_df.sort_values(
+        by=["__yoe_sort", "company", "title"], ascending=True
+    ).drop(columns=["__yoe_sort"])
+
+
+def send_email(subject: str, body_text: str, body_html: str | None = None) -> bool:
+    host = os.getenv("SMTP_HOST", "").strip()
+    port = int(os.getenv("SMTP_PORT", "587"))
+    user = os.getenv("SMTP_USER", "").strip()
+    password = os.getenv("SMTP_PASS", "").strip()
+    to_addr = os.getenv("EMAIL_TO", "").strip()
+    from_addr = os.getenv("EMAIL_FROM", "").strip() or user
+
+    if not (host and user and password and to_addr):
+        print("Email not sent: missing SMTP_HOST/SMTP_USER/SMTP_PASS/EMAIL_TO.")
+        return False
+
+    msg = EmailMessage()
+    msg["Subject"] = subject
+    msg["From"] = from_addr
+    msg["To"] = to_addr
+    msg.set_content(body_text)
+    if body_html:
+        msg.add_alternative(body_html, subtype="html")
+
+    with smtplib.SMTP(host, port) as smtp:
+        smtp.starttls()
+        smtp.login(user, password)
+        smtp.send_message(msg)
+    return True
+
+
+def save_master(master: pd.DataFrame | None, new_rows: pd.DataFrame) -> None:
+    if master is None or master.empty:
+        final = keep_final_columns(new_rows)
+    else:
+        final = pd.concat([keep_final_columns(master), keep_final_columns(new_rows)])
+        final = final.drop_duplicates(subset=["site", "id"], keep="first")
+
+    final.to_csv(
+        MASTER_CSV_PATH,
+        index=False,
+        quoting=csv.QUOTE_MINIMAL,
+        escapechar="\\",
+    )
+    print(f"Saved master: {len(final)} rows -> {MASTER_CSV_PATH}")
+
+
+def main() -> None:
+    from enrich_yoe import enrich_jobs_with_yoe
+
+    master = load_master()
+
+    new_jobs = scrape_jobs(
+        site_name=["linkedin"],
+        search_term=SEARCH_TERM,
+        location=LOCATION,
+        results_wanted=RESULTS_WANTED,
+        hours_old=HOURS_OLD,
+        linkedin_fetch_description=True,
+    )
+
+    if new_jobs is None or new_jobs.empty:
+        print("No jobs scraped.")
+        write_markdown_report(pd.DataFrame())
+        return
+
+    new_jobs = prepare_jobs_for_dedupe(new_jobs)
+    new_jobs = internal_dedupe_new_batch(new_jobs)
+    new_jobs = filter_new_vs_master(master, new_jobs)
+    print(f"After dedupe vs master: {len(new_jobs)} new unique jobs")
+
+    new_jobs = filter_excluded_companies(new_jobs)
+
+    candidate_jobs = filter_under_applicant_limit(new_jobs)
+    if candidate_jobs.empty:
+        write_markdown_report(pd.DataFrame())
+        print("No new jobs under applicant limit to evaluate.")
+        return
+
+    desc_col = find_description_column(candidate_jobs)
+    candidate_jobs["_desc"] = candidate_jobs[desc_col].astype(str).fillna("").str.strip()
+    candidate_jobs = candidate_jobs.loc[candidate_jobs["_desc"].str.len() > 0].copy()
+    candidate_jobs.drop(columns=["_desc"], inplace=True)
+
+    if candidate_jobs.empty:
+        write_markdown_report(pd.DataFrame())
+        print("No new jobs with descriptions to evaluate.")
+        return
+
+    enriched_jobs = enrich_jobs_with_yoe(
+        candidate_jobs,
+        desc_col,
+        checkpoint_path=YOE_CHECKPOINT_PATH,
+        checkpoint_every=10,
+    )
+
+    jobs_to_notify = filter_by_max_yoe(enriched_jobs)
+    jobs_to_notify = keep_final_columns(jobs_to_notify)
+    write_markdown_report(jobs_to_notify)
+
+    if jobs_to_notify.empty:
+        print("No new jobs under applicant and YOE limits to notify.")
+        return
+
+    email_sent = send_email(
+        subject=(
+            f"[LinkedIn jobs under {APPLICANT_LIMIT} applicants, "
+            f"YOE <= {MAX_YOE_REQUIRED}] "
+            f"{len(jobs_to_notify)} new jobs"
+        ),
+        body_text=(
+            f"LinkedIn jobs under {APPLICANT_LIMIT} applicants "
+            f"and YOE <= {MAX_YOE_REQUIRED}:\n\n"
+            + df_to_plain_table(jobs_to_notify)
+        ),
+        body_html=(
+            f"<h3>LinkedIn jobs under {APPLICANT_LIMIT} applicants "
+            f"and YOE <= {MAX_YOE_REQUIRED}</h3>"
+            + df_to_html_table(jobs_to_notify)
+        ),
+    )
+
+    if email_sent:
+        print(f"Emailed {len(jobs_to_notify)} jobs.")
+        save_master(master, keep_final_columns(enriched_jobs))
+        print(f"Wrote report: {REPORT_MD_PATH}")
+    else:
+        print("Master was not updated because email was not sent.")
+
+
+if __name__ == "__main__":
+    main()

--- a/local_scripts/linkedin_applicant_notifier/yoe_llm_client.py
+++ b/local_scripts/linkedin_applicant_notifier/yoe_llm_client.py
@@ -19,7 +19,7 @@ if not API_KEY:
 BASE_URL = "https://api.novita.ai/openai"
 MODEL_ID = os.getenv("NOVITA_MODEL_ID", "meta-llama/llama-3.1-8b-instruct")
 DB_PATH = os.getenv("YOE_LLM_CACHE_DB", "yoe_llm_cache.sqlite3")
-PROMPT_VERSION = "yoe-required-v1"
+PROMPT_VERSION = "yoe-required-and-skill-fit-v1"
 
 MIN_SECONDS_BETWEEN_CALLS = float(os.getenv("YOE_LLM_MIN_SECONDS", "1.25"))
 MAX_RETRIES = 6
@@ -30,12 +30,13 @@ client = OpenAI(api_key=API_KEY, base_url=BASE_URL)
 SYSTEM_TEMPLATE = """You are an information extraction assistant.
 You MUST output only valid JSON. No markdown, no code fences, no explanations."""
 
-USER_TEMPLATE = """Extract the minimum required PROFESSIONAL software engineering years of experience from this job posting.
+USER_TEMPLATE = """Extract the minimum required PROFESSIONAL software engineering years of experience and whether this job is a good skill fit.
 
 Return strict JSON with exactly these keys:
 1) "yoe_required": integer
+2) "skill_fit": boolean
 
-Rules:
+YOE rules:
 - Count only required professional work experience.
 - Do not count education requirements as years of experience.
 - Degree requirements alone always count as 0 years.
@@ -54,6 +55,23 @@ Rules:
 - If the years of experience are listed as preferred, nice-to-have, a plus, desired, or optional, do not count them.
 - If the posting says “new grad,” “entry level,” “university grad,” “recent graduate,” or “no experience required,” output 0.
 - If no required professional YOE is clearly specified, output 0.
+- Return only the required JSON object.
+
+Skill-fit profile:
+- Programming: Java, Python, Go, JavaScript, TypeScript, C++, C#, SQL, Bash, HTML, CSS.
+- Backend: Spring Boot, Node.js, Express.js, FastAPI, Django, Flask, REST APIs, GraphQL, gRPC, WebSockets, OAuth2, JWT, RBAC, microservices.
+- Frontend: React, Angular, Next.js, Redux Toolkit, TypeScript, dashboards, real-time visualization.
+- Cloud: AWS, Azure, GCP, EC2, EKS, S3, RDS, Lambda, Glue, EMR, Redshift, VMs, Blob Storage, ADLS Gen2, Kubernetes, BigQuery, Dataflow.
+- Databases: PostgreSQL, MongoDB, Redis, Cassandra, MySQL, SQL Server, SQLite, Pinecone, Neo4j, InfluxDB, Elasticsearch, ClickHouse, DuckDB.
+- DevOps/infrastructure: Docker, Kubernetes, Terraform, GitHub Actions, Jenkins, CI/CD, Helm, Git, Prometheus, Grafana, Ansible, Jira, Karpenter, HPA, monitoring.
+- Data engineering: PySpark, Spark, Flink, Kafka, Airflow, Hadoop, Hive, Iceberg, Hudi, Delta Lake, dbt, Snowflake, Databricks, NiFi, Debezium, ETL/ELT, data lakes, warehouses, streaming.
+- AI/ML/LLM: LangChain, RAG, LangGraph, MCP, Hugging Face, vector embeddings, BM25, TensorFlow, Keras, OpenCV, NLTK, scikit-learn.
+
+Skill-fit rules:
+- skill_fit=true for software engineer, backend, full stack, Java backend, cloud, platform, DevOps, infrastructure, data engineer, big data, ML, AI, LLM, RAG, or distributed systems roles that overlap with the profile.
+- skill_fit=true if the job uses several listed technologies even when the title is broad.
+- skill_fit=false only when the role is clearly outside this profile, such as sales, marketing, customer support, help desk, product/project manager, business analyst, recruiter, pure UI/UX design, mechanical/electrical/civil engineering, embedded hardware, ERP admin, Salesforce-only admin, ServiceNow-only admin, manual QA with no automation/software engineering, or roles dominated by skills not in the profile.
+- Be conservative: if it is plausibly a software/backend/full-stack/data/cloud/platform/AI engineering role, output true.
 - Return only the required JSON object.
 
 Company: {company}
@@ -152,9 +170,24 @@ def _coerce_yoe(value: Any) -> int:
     return 0
 
 
+def _coerce_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        text = value.strip().lower()
+        if text in {"true", "yes", "y", "1", "fit", "match"}:
+            return True
+        if text in {"false", "no", "n", "0", "not_fit", "not fit", "no_match"}:
+            return False
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return False
+
+
 def _validate_output(data: dict[str, Any]) -> dict[str, Any]:
     return {
         "yoe_required": _coerce_yoe(data.get("yoe_required", 0)),
+        "skill_fit": _coerce_bool(data.get("skill_fit", False)),
         "extracted_time": "",
     }
 
@@ -192,6 +225,7 @@ def extract_yoe_requirement(company: str, title: str, job_description: str) -> d
     if not jd:
         return {
             "yoe_required": 0,
+            "skill_fit": False,
             "extracted_time": _utc_now_iso(),
         }
 
@@ -208,8 +242,7 @@ def extract_yoe_requirement(company: str, title: str, job_description: str) -> d
         job_description=jd,
     )
 
-    validated = _validate_output(_call_llm(user_prompt, max_tokens=40))
+    validated = _validate_output(_call_llm(user_prompt, max_tokens=80))
     validated["extracted_time"] = _utc_now_iso()
     _cache_set(cache_key, validated)
     return validated
-

--- a/local_scripts/linkedin_applicant_notifier/yoe_llm_client.py
+++ b/local_scripts/linkedin_applicant_notifier/yoe_llm_client.py
@@ -58,7 +58,7 @@ YOE rules:
 - Return only the required JSON object.
 
 Skill-fit profile:
-- Programming: Java, Python, Go, JavaScript, TypeScript, C++, C#, SQL, Bash, HTML, CSS.
+- Programming: Java, Python, Go, JavaScript, TypeScript, SQL, Bash, HTML, CSS.
 - Backend: Spring Boot, Node.js, Express.js, FastAPI, Django, Flask, REST APIs, GraphQL, gRPC, WebSockets, OAuth2, JWT, RBAC, microservices.
 - Frontend: React, Angular, Next.js, Redux Toolkit, TypeScript, dashboards, real-time visualization.
 - Cloud: AWS, Azure, GCP, EC2, EKS, S3, RDS, Lambda, Glue, EMR, Redshift, VMs, Blob Storage, ADLS Gen2, Kubernetes, BigQuery, Dataflow.

--- a/local_scripts/linkedin_applicant_notifier/yoe_llm_client.py
+++ b/local_scripts/linkedin_applicant_notifier/yoe_llm_client.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import random
+import re
+import sqlite3
+import time
+from datetime import datetime, timezone
+from typing import Any
+
+from openai import APIConnectionError, APIError, APITimeoutError, OpenAI, RateLimitError
+
+API_KEY = os.getenv("NOVITA_API_KEY", "").strip()
+if not API_KEY:
+    raise RuntimeError("NOVITA_API_KEY is not set in your environment or .env file.")
+
+BASE_URL = "https://api.novita.ai/openai"
+MODEL_ID = os.getenv("NOVITA_MODEL_ID", "meta-llama/llama-3.1-8b-instruct")
+DB_PATH = os.getenv("YOE_LLM_CACHE_DB", "yoe_llm_cache.sqlite3")
+PROMPT_VERSION = "yoe-required-v1"
+
+MIN_SECONDS_BETWEEN_CALLS = float(os.getenv("YOE_LLM_MIN_SECONDS", "1.25"))
+MAX_RETRIES = 6
+_last_call_ts = 0.0
+
+client = OpenAI(api_key=API_KEY, base_url=BASE_URL)
+
+SYSTEM_TEMPLATE = """You are an information extraction assistant.
+You MUST output only valid JSON. No markdown, no code fences, no explanations."""
+
+USER_TEMPLATE = """Extract the minimum required PROFESSIONAL software engineering years of experience from this job posting.
+
+Return strict JSON with exactly these keys:
+1) "yoe_required": integer
+
+Rules:
+- Count only required professional work experience.
+- Do not count education requirements as years of experience.
+- Degree requirements alone always count as 0 years.
+- A Bachelor's degree, Master's degree, PhD, or any degree requirement without an explicit professional years requirement means 0 years.
+- If the posting says “Bachelor’s or Master’s degree” with no professional years requirement, output 0.
+- If the posting says “Bachelor’s degree or equivalent practical experience” with no explicit number of professional years, output 0.
+- If the posting says a degree OR a number of years of experience, treat the years as an alternative to education, not a required YOE amount. Output 0.
+- Example: “Bachelor’s degree or 4+ years of relevant experience” → 0.
+- Example: “Bachelor’s degree or equivalent practical experience” → 0.
+- If the posting clearly requires professional experience regardless of education, count the stated minimum.
+- Example: “4+ years of software engineering experience” → 4.
+- Example: “Bachelor’s degree and 4+ years of software engineering experience” → 4.
+- If the posting gives a range, output the lower bound.
+- Example: “2-4 years” → 2.
+- Example: “2 to 4 years” → 2.
+- If the years of experience are listed as preferred, nice-to-have, a plus, desired, or optional, do not count them.
+- If the posting says “new grad,” “entry level,” “university grad,” “recent graduate,” or “no experience required,” output 0.
+- If no required professional YOE is clearly specified, output 0.
+- Return only the required JSON object.
+
+Company: {company}
+Title: {title}
+
+Job description:
+{job_description}
+"""
+
+def _init_db() -> None:
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS cache (
+                cache_key TEXT PRIMARY KEY,
+                value_json TEXT NOT NULL,
+                created_utc TEXT NOT NULL
+            )
+            """
+        )
+        conn.commit()
+
+
+_init_db()
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _make_cache_key(model: str, prompt_version: str, company: str, title: str, jd: str) -> str:
+    normalized = "\n".join([company.strip(), title.strip(), jd.strip()])
+    return hashlib.sha256(
+        f"{model}|{prompt_version}|{normalized}".encode("utf-8")
+    ).hexdigest()
+
+
+def _cache_get(cache_key: str) -> dict[str, Any] | None:
+    with sqlite3.connect(DB_PATH) as conn:
+        row = conn.execute(
+            "SELECT value_json FROM cache WHERE cache_key = ?",
+            (cache_key,),
+        ).fetchone()
+    if not row:
+        return None
+    try:
+        return json.loads(row[0])
+    except Exception:
+        return None
+
+
+def _cache_set(cache_key: str, value: dict[str, Any]) -> None:
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute(
+            "INSERT OR REPLACE INTO cache(cache_key, value_json, created_utc) VALUES(?,?,?)",
+            (cache_key, json.dumps(value, ensure_ascii=False), _utc_now_iso()),
+        )
+        conn.commit()
+
+
+def _throttle() -> None:
+    global _last_call_ts
+    now = time.time()
+    wait = MIN_SECONDS_BETWEEN_CALLS - (now - _last_call_ts)
+    if wait > 0:
+        time.sleep(wait)
+    _last_call_ts = time.time()
+
+
+def _safe_json_loads(value: str) -> dict[str, Any]:
+    try:
+        return json.loads(value)
+    except Exception:
+        pass
+
+    match = re.search(r"\{[\s\S]*\}", value)
+    if match:
+        try:
+            return json.loads(match.group(0))
+        except Exception:
+            pass
+    return {}
+
+
+def _coerce_yoe(value: Any) -> int:
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, int):
+        return max(0, min(value, 50))
+    if isinstance(value, float) and value.is_integer():
+        return max(0, min(int(value), 50))
+    if isinstance(value, str):
+        match = re.search(r"\d+", value)
+        if match:
+            return max(0, min(int(match.group()), 50))
+    return 0
+
+
+def _validate_output(data: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "yoe_required": _coerce_yoe(data.get("yoe_required", 0)),
+        "extracted_time": "",
+    }
+
+
+def _call_llm(user_prompt: str, max_tokens: int) -> dict[str, Any]:
+    for attempt in range(1, MAX_RETRIES + 1):
+        try:
+            _throttle()
+            response = client.chat.completions.create(
+                model=MODEL_ID,
+                messages=[
+                    {"role": "system", "content": SYSTEM_TEMPLATE},
+                    {"role": "user", "content": user_prompt},
+                ],
+                temperature=0.0,
+                max_tokens=max_tokens,
+            )
+            raw = (response.choices[0].message.content or "").strip()
+            return _safe_json_loads(raw)
+        except RateLimitError:
+            time.sleep(min(60, 2**attempt) + random.random())
+        except (APITimeoutError, APIConnectionError, APIError):
+            time.sleep(min(30, 2**attempt) + random.random())
+        except Exception:
+            time.sleep(min(20, 2**attempt) + random.random())
+
+    return {}
+
+
+def extract_yoe_requirement(company: str, title: str, job_description: str) -> dict[str, Any]:
+    company = (company or "").strip()
+    title = (title or "").strip()
+    jd = str(job_description or "").strip()[:8000]
+
+    if not jd:
+        return {
+            "yoe_required": 0,
+            "extracted_time": _utc_now_iso(),
+        }
+
+    cache_key = _make_cache_key(MODEL_ID, PROMPT_VERSION, company, title, jd)
+    cached = _cache_get(cache_key)
+    if cached is not None:
+        out = _validate_output(cached)
+        out["extracted_time"] = cached.get("extracted_time") or _utc_now_iso()
+        return out
+
+    user_prompt = USER_TEMPLATE.format(
+        company=company,
+        title=title,
+        job_description=jd,
+    )
+
+    validated = _validate_output(_call_llm(user_prompt, max_tokens=40))
+    validated["extracted_time"] = _utc_now_iso()
+    _cache_set(cache_key, validated)
+    return validated
+


### PR DESCRIPTION
## Summary
- Add an optional `applicants` field to `JobPost`
- Parse LinkedIn applicant text from job detail pages
- Include `applicants` in the output dataframe column order

## Notes
LinkedIn applicant text is only available when `linkedin_fetch_description=True`, because it comes from the job detail page.

Examples captured:
- `90 applicants`
- `123 applicants`
- `Over 200 applicants`
- `Be among the first 25 applicants`

## Validation
- Ran `.\.venv\Scripts\python.exe -m compileall jobspy`
- Manually verified with LinkedIn detail HTML dumps