### PR TITLE
feat(linkedin): add company LinkedIn ID to job posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ jobs = scrape_jobs(
     hours_old=72,
     country_indeed='USA',
     
-    # linkedin_fetch_description=True # gets more info such as description, direct job url (slower)
+    # linkedin_fetch_description=True # gets more info such as description, direct job url, linkedin company id (slower)
     # proxies=["208.195.175.46:65095", "208.195.175.45:65095", "localhost"],
 )
 print(f"Found {len(jobs)} jobs")
@@ -105,7 +105,7 @@ Optional
 |    (0 prints only errors, 1 is errors+warnings, 2 is all logs. Default is 2.)
 
 ├── linkedin_fetch_description (bool): 
-|    fetches full description and direct job url for LinkedIn (Increases requests by O(n))
+|    fetches full description, direct job url, and company_linkedin_id for LinkedIn (Increases requests by O(n))
 │
 ├── linkedin_company_ids (list[int]): 
 |    searches for linkedin jobs with specific company ids
@@ -237,6 +237,7 @@ JobPost
 └── emails
 
 Linkedin specific
+├── company_linkedin_id
 └── job_level
 
 Linkedin & Indeed specific

--- a/jobspy/linkedin/__init__.py
+++ b/jobspy/linkedin/__init__.py
@@ -231,6 +231,7 @@ class LinkedIn(Scraper):
             title=title,
             company_name=company,
             company_url=company_url,
+            company_linkedin_id=job_details.get("company_linkedin_id"),
             location=location,
             is_remote=is_remote,
             date_posted=date_posted,
@@ -291,8 +292,15 @@ class LinkedIn(Scraper):
             if (logo_image := soup.find("img", {"class": "artdeco-entity-image"}))
             else None
         )
+        company_id_tag = soup.find("meta", attrs={"name": "companyId"})
+        company_linkedin_id = (
+            company_id_tag.get("content")
+            if company_id_tag and company_id_tag.get("content", "").isdigit()
+            else None
+        )
         return {
             "description": description,
+            "company_linkedin_id": company_linkedin_id,
             "job_level": parse_job_level(soup),
             "company_industry": parse_company_industry(soup),
             "job_type": parse_job_type(soup),

--- a/jobspy/model.py
+++ b/jobspy/model.py
@@ -256,6 +256,7 @@ class JobPost(BaseModel):
     listing_type: str | None = None
 
     # LinkedIn specific
+    company_linkedin_id: str | None = None
     job_level: str | None = None
 
     # LinkedIn and Indeed specific

--- a/jobspy/util.py
+++ b/jobspy/util.py
@@ -353,6 +353,7 @@ desired_order = [
     "company_num_employees",
     "company_revenue",
     "company_description",
+    "company_linkedin_id",
     # naukri-specific fields
     "skills",
     "experience_range",


### PR DESCRIPTION
## Summary

Adds company_linkedin_id to the retrieved fields when linkedin_fetch_description==True.

Linkedin company ids can already be used for filtering in linkedin search, but there is no easy way to retrieve them. You have to look up the company page manually (or use an external dataset but only ones I could find are pretty old).

So I think being able to retrieve the company ids while scraping would make it easier to reuse them later on for future searches.

## Changes
- jobspy/linkedin/__init__.py : Retrieved company_linkedin_id from the job detail page using the meta tag "companyId"
- jobspy/model.py and jobspy/util.py:  Added new field to the JobPost model and the output order df
- README.md: Added new field info

## Testing

- I have tested it locally with about 1000 jobs parsed over the past days
- To test quickly, you can use the script

```
from jobspy import scrape_jobs

df=scrape_jobs(site_name='linkedin', search_term='software engineer', location='United States', results_wanted=10, linkedin_fetch_description=True)

print(df[['title','company','company_linkedin_id','job_url']].to_string(index=False))
```

Output at the time of the PR:

| Title | Company | Company LinkedIn ID | Job URL |
|---|---|---|---|
| Software Engineer | Nuvo | 82490513 | https://www.linkedin.com/jobs/view/4378357766 |
| Software Engineer | Chalk | 78829224 | https://www.linkedin.com/jobs/view/4406548495 |
| Software Developer | Weekday (YC W21) | 69656080 | https://www.linkedin.com/jobs/view/4432097763 |
| Software Engineer (All Levels) | Blossom | 104568728 | https://www.linkedin.com/jobs/view/4432033379 |
| Software Engineer | Yext | 515401 | https://www.linkedin.com/jobs/view/4081518713 |
| Software Engineer | Rilla | 11745039 | https://www.linkedin.com/jobs/view/4427404272 |
| Software Engineer | Oso | 13056430 | https://www.linkedin.com/jobs/view/4363726700 |
| Software Engineer | Candid Health | 70448411 | https://www.linkedin.com/jobs/view/4339199299 |
| Software Engineer | Moab | 100925956 | https://www.linkedin.com/jobs/view/4318517031 |
| Software Engineer | Voltai | 99344719 | https://www.linkedin.com/jobs/view/4318514364 |