### PR TITLE
fix: datetime precision, Glassdoor CSRF/GraphQL, LinkedIn company ID

### DIFF
--- a/jobspy/glassdoor/__init__.py
+++ b/jobspy/glassdoor/__init__.py
@@ -4,7 +4,7 @@ import re
 import json
 import requests
 from typing import Tuple
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from jobspy.glassdoor.constant import fallback_token, query_template, headers
@@ -121,7 +121,20 @@ class Glassdoor(Scraper):
                 raise GlassdoorException(exc_msg)
             res_json = response.json()[0]
             if "errors" in res_json:
-                raise ValueError("Error encountered in API response")
+                # Only treat errors on the jobListings field as fatal.
+                # Glassdoor commonly returns non-critical 503s on peripheral
+                # fields (e.g. jobsPageSeoData) while the job data is intact.
+                # See https://github.com/speedyapply/JobSpy/pull/347
+                job_errors = [
+                    e
+                    for e in res_json["errors"]
+                    if "jobListings" in str(e.get("path", []))
+                    and "jobsPageSeoData" not in str(e.get("path", []))
+                ]
+                if job_errors:
+                    raise ValueError(
+                        f"Error encountered in jobListings API response: {job_errors}"
+                    )
         except (
             requests.exceptions.ReadTimeout,
             GlassdoorException,
@@ -151,9 +164,11 @@ class Glassdoor(Scraper):
 
     def _get_csrf_token(self):
         """
-        Fetches csrf token needed for API by visiting a generic page
+        Fetches csrf token needed for API by visiting the homepage.
+        Previously used /Job/computer-science-jobs.htm which now returns 404
+        after Glassdoor's Next.js migration (JobSpy #347).
         """
-        res = self.session.get(f"{self.base_url}/Job/computer-science-jobs.htm")
+        res = self.session.get(f"{self.base_url}/")
         pattern = r'"token":\s*"([^"]+)"'
         matches = re.findall(pattern, res.text)
         token = None
@@ -178,8 +193,15 @@ class Glassdoor(Scraper):
         location_type = job["header"].get("locationType", "")
         age_in_days = job["header"].get("ageInDays")
         is_remote, location = False, None
-        date_diff = (datetime.now() - timedelta(days=age_in_days)).date()
-        date_posted = date_diff if age_in_days is not None else None
+        if age_in_days is not None:
+            # Noon UTC so day-bucketed ages don't immediately fail a 24h filter.
+            date_posted = (datetime.now(timezone.utc) - timedelta(days=age_in_days)).replace(
+                hour=12, minute=0, second=0, microsecond=0
+            )
+            posted_at_source = "glassdoor_age_in_days"
+        else:
+            date_posted = None
+            posted_at_source = None
 
         if location_type == "S":
             is_remote = True
@@ -207,6 +229,7 @@ class Glassdoor(Scraper):
             company_url=company_url if company_id else None,
             company_name=company_name,
             date_posted=date_posted,
+            posted_at_source=posted_at_source,
             job_url=job_url,
             location=location,
             compensation=compensation,

--- a/jobspy/indeed/__init__.py
+++ b/jobspy/indeed/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import math
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Tuple
 
 from jobspy.indeed.constant import job_search_query, api_headers
@@ -207,8 +207,9 @@ class Indeed(Scraper):
             description = markdown_converter(description)
 
         job_type = get_job_type(job["attributes"])
+        # Preserve full ms-precision publish time (upstream used to truncate to date).
         timestamp_seconds = job["datePublished"] / 1000
-        date_posted = datetime.fromtimestamp(timestamp_seconds).strftime("%Y-%m-%d")
+        date_posted = datetime.fromtimestamp(timestamp_seconds, tz=timezone.utc)
         employer = job["employer"].get("dossier") if job["employer"] else None
         employer_details = employer.get("employerDetails", {}) if employer else {}
         rel_url = job["employer"]["relativeCompanyPageUrl"] if job["employer"] else None
@@ -229,6 +230,7 @@ class Indeed(Scraper):
             job_type=job_type,
             compensation=get_compensation(job["compensation"]),
             date_posted=date_posted,
+            posted_at_source="indeed_date_published",
             job_url=job_url,
             job_url_direct=(
                 job["recruit"].get("viewJobUrl") if job.get("recruit") else None

--- a/jobspy/linkedin/__init__.py
+++ b/jobspy/linkedin/__init__.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import math
 import random
 import time
-from datetime import datetime
 from typing import Optional
 from urllib.parse import urlparse, urlunparse, unquote
 
@@ -18,7 +17,8 @@ from jobspy.linkedin.util import (
     job_type_code,
     parse_job_type,
     parse_job_level,
-    parse_company_industry
+    parse_company_industry,
+    parse_job_datetime,
 )
 from jobspy.model import (
     JobPost,
@@ -213,13 +213,7 @@ class LinkedIn(Scraper):
             datetime_tag = metadata_card.find(
                 "time", class_="job-search-card__listdate--new"
             )
-        date_posted = None
-        if datetime_tag and "datetime" in datetime_tag.attrs:
-            datetime_str = datetime_tag["datetime"]
-            try:
-                date_posted = datetime.strptime(datetime_str, "%Y-%m-%d")
-            except:
-                date_posted = None
+        date_posted, posted_at_source = parse_job_datetime(datetime_tag)
         job_details = {}
         if full_descr:
             job_details = self._get_job_details(job_id)
@@ -231,9 +225,11 @@ class LinkedIn(Scraper):
             title=title,
             company_name=company,
             company_url=company_url,
+            company_linkedin_id=job_details.get("company_linkedin_id"),
             location=location,
             is_remote=is_remote,
             date_posted=date_posted,
+            posted_at_source=posted_at_source,
             job_url=f"{self.base_url}/jobs/view/{job_id}",
             compensation=compensation,
             job_type=job_details.get("job_type"),
@@ -291,8 +287,15 @@ class LinkedIn(Scraper):
             if (logo_image := soup.find("img", {"class": "artdeco-entity-image"}))
             else None
         )
+        company_id_tag = soup.find("meta", attrs={"name": "companyId"})
+        company_linkedin_id = (
+            company_id_tag.get("content")
+            if company_id_tag and company_id_tag.get("content", "").isdigit()
+            else None
+        )
         return {
             "description": description,
+            "company_linkedin_id": company_linkedin_id,
             "job_level": parse_job_level(soup),
             "company_industry": parse_company_industry(soup),
             "job_type": parse_job_type(soup),

--- a/jobspy/linkedin/util.py
+++ b/jobspy/linkedin/util.py
@@ -1,7 +1,15 @@
+import re
+from datetime import datetime, timedelta, timezone
+
 from bs4 import BeautifulSoup
 
 from jobspy.model import JobType, Location
 from jobspy.util import get_enum_from_job_type
+
+_RELATIVE_RE = re.compile(
+    r"^\s*(?:just\s+now|today|yesterday|(\d+)\s*(minute|minutes|min|hour|hours|hr|hrs|day|days|week|weeks|month|months|year|years)\s+ago)\s*$",
+    re.IGNORECASE,
+)
 
 
 def job_type_code(job_type_enum: JobType) -> str:
@@ -85,12 +93,62 @@ def parse_company_industry(soup_industry: BeautifulSoup) -> str | None:
     return industry
 
 
+def parse_job_datetime(time_tag) -> tuple[datetime | None, str | None]:
+    """Parse LinkedIn <time> into a datetime + provenance.
+
+    Prefers relative text ("3 hours ago") for hour-level precision; falls back
+    to the datetime="YYYY-MM-DD" attribute (day precision only).
+    """
+    if time_tag is None:
+        return None, None
+
+    now = datetime.now(timezone.utc)
+    text = time_tag.get_text(strip=True) or ""
+    match = _RELATIVE_RE.match(text)
+    if match:
+        lower = text.lower().strip()
+        if lower in ("just now", "today"):
+            return now, "linkedin_relative_text"
+        if lower == "yesterday":
+            return now - timedelta(days=1), "linkedin_relative_text"
+
+        amount = int(match.group(1))
+        unit = match.group(2).lower()
+        if unit.startswith("min"):
+            delta = timedelta(minutes=amount)
+        elif unit.startswith("hour") or unit.startswith("hr"):
+            delta = timedelta(hours=amount)
+        elif unit.startswith("day"):
+            delta = timedelta(days=amount)
+        elif unit.startswith("week"):
+            delta = timedelta(weeks=amount)
+        elif unit.startswith("month"):
+            delta = timedelta(days=30 * amount)
+        else:
+            delta = timedelta(days=365 * amount)
+        return now - delta, "linkedin_relative_text"
+
+    datetime_attr = time_tag.get("datetime")
+    if datetime_attr:
+        try:
+            # Date-only attribute → noon UTC so "yesterday" doesn't look >24h
+            # the moment local midnight rolls over.
+            parsed = datetime.strptime(datetime_attr, "%Y-%m-%d").replace(
+                hour=12, tzinfo=timezone.utc
+            )
+            return parsed, "linkedin_datetime_attr"
+        except ValueError:
+            pass
+
+    return None, None
+
+
 def is_job_remote(title: dict, description: str, location: Location) -> bool:
     """
     Searches the title, location, and description to check if job is remote
     """
     remote_keywords = ["remote", "work from home", "wfh"]
     location = location.display_location()
-    full_string = f'{title} {description} {location}'.lower()
+    full_string = f"{title} {description} {location}".lower()
     is_remote = any(keyword in full_string for keyword in remote_keywords)
     return is_remote

--- a/jobspy/model.py
+++ b/jobspy/model.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from typing import Optional
-from datetime import date
+from datetime import date, datetime
 from enum import Enum
 from pydantic import BaseModel
 
@@ -250,12 +250,17 @@ class JobPost(BaseModel):
 
     job_type: list[JobType] | None = None
     compensation: Compensation | None = None
-    date_posted: date | None = None
+    # date for day-only sources; datetime when hour+ precision is available
+    date_posted: date | datetime | None = None
+    # Provenance for consumers that care about freshness confidence
+    # e.g. linkedin_relative_text | linkedin_datetime_attr | indeed_date_published
+    posted_at_source: str | None = None
     emails: list[str] | None = None
     is_remote: bool | None = None
     listing_type: str | None = None
 
     # LinkedIn specific
+    company_linkedin_id: str | None = None
     job_level: str | None = None
 
     # LinkedIn and Indeed specific

--- a/jobspy/util.py
+++ b/jobspy/util.py
@@ -333,6 +333,7 @@ desired_order = [
     "company",
     "location",
     "date_posted",
+    "posted_at_source",
     "job_type",
     "salary_source",
     "interval",
@@ -353,6 +354,7 @@ desired_order = [
     "company_num_employees",
     "company_revenue",
     "company_description",
+    "company_linkedin_id",
     # naukri-specific fields
     "skills",
     "experience_range",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "python-jobspy"
-version = "1.1.82"
+version = "1.1.82+jaos.1"
 description = "Job scraper for LinkedIn, Indeed, Glassdoor, ZipRecruiter & Bayt"
 authors = ["Cullen Watson <cullen@cullenwatson.com>", "Zachary Hampton <zachary@zacharysproducts.com>"]
 homepage = "https://github.com/cullenwatson/JobSpy"


### PR DESCRIPTION
## Summary

Hardens JobSpy posting timestamps and restores Glassdoor for consumers that need real freshness (used by [Job Acquisition OS](https://github.com/dantekelly/Job-Acquisition-OS) / AIT-109). Combines and extends several open/unreleased upstream threads.

### Changes

1. **LinkedIn dates** — Prefer relative text (`\"3 hours ago\"`) for hour-level `date_posted`; fall back to `datetime` attr. Continues to support `job-search-card__listdate--new` (already on main via #343).
2. **Indeed timestamps** — Keep `datePublished` as a timezone-aware UTC `datetime` instead of truncating to `YYYY-MM-DD`.
3. **`posted_at_source` provenance** — New optional field: `linkedin_relative_text` | `linkedin_datetime_attr` | `indeed_date_published` | `glassdoor_age_in_days`.
4. **Glassdoor** — Apply [#347](https://github.com/speedyapply/JobSpy/pull/347): CSRF from homepage (not 404 job page) + treat GraphQL SEO/`jobsPageSeoData` errors as non-fatal.
5. **LinkedIn company ID** — Apply [#371](https://github.com/speedyapply/JobSpy/pull/371): `company_linkedin_id` when `linkedin_fetch_description=True`.

`date_posted` typing is now `date | datetime | None` so sources with real clock times are not forced through a date-only field.

### Test plan

- [x] LinkedIn scrape: near-zero null `date_posted`; relative-text provenance; `company_linkedin_id` present with description fetch
- [x] Indeed scrape: `date_posted` is datetime with hour+ precision + `indeed_date_published`
- [x] Glassdoor: #347 applied; note some datacenter IPs still get homepage 403 (bot block) — verify from residential/proxy
- [ ] Confirm dataframe export still sorts/filters cleanly with mixed `date`/`datetime` values

```python
from jobspy import scrape_jobs
df = scrape_jobs(
    site_name=[\"linkedin\", \"indeed\", \"glassdoor\"],
    search_term=\"senior frontend engineer\",
    location=\"United States\",
    is_remote=True,
    results_wanted=10,
    hours_old=24,
    linkedin_fetch_description=True,
)
print(df[[\"site\", \"title\", \"date_posted\", \"posted_at_source\", \"company_linkedin_id\"]].head(20))
```

### Related

- Builds on / overlaps: #343 (merged), #345, #347, #371
- Consumer: https://github.com/dantekelly/Job-Acquisition-OS/pull/5


Made with [Cursor](https://cursor.com)